### PR TITLE
Generic blackboard implementation

### DIFF
--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -12,7 +12,7 @@ name = "bonsai-bt"
 readme = "../README.md"
 repository = "https://github.com/sollimann/bonsai.git"
 rust-version = "1.60.0"
-version = "0.5.0"
+version = "0.6.0"
 
 [lib]
 name = "bonsai_bt"

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -4,7 +4,7 @@ use petgraph::dot::{Config, Dot};
 use petgraph::{stable_graph::NodeIndex, Graph};
 
 use crate::visualizer::NodeType;
-use crate::{Behavior, State};
+use crate::{ActionArgs, Behavior, State, Status, UpdateEvent};
 
 /// A "blackboard" is a simple key/value storage shared by all the nodes of the Tree.
 ///
@@ -55,6 +55,15 @@ impl<A: Clone + Debug, K: Debug> BT<A, K> {
             graph,
             root_id,
         }
+    }
+
+    pub fn tick<E, F>(&mut self, e: &E, f: &mut F) -> (Status, f64)
+    where
+        E: UpdateEvent,
+        F: FnMut(ActionArgs<E, A>, &mut BlackBoard<K>) -> (Status, f64),
+        A: Debug,
+    {
+        self.state.tick(e, &mut self.bb, f)
     }
 
     /// Compile the behavior tree into a [graphviz](https://graphviz.org/) compatible [DiGraph](https://docs.rs/petgraph/latest/petgraph/graph/type.DiGraph.html).

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 
 use petgraph::dot::{Config, Dot};
@@ -16,10 +15,10 @@ use crate::{Behavior, State};
 ///
 /// An "entry" of the Blackboard is a key/value pair.
 #[derive(Clone, Debug)]
-pub struct BlackBoard<K, V>(HashMap<K, V>);
+pub struct BlackBoard<K>(K);
 
-impl<K, V> BlackBoard<K, V> {
-    pub fn get_db(&mut self) -> &mut HashMap<K, V> {
+impl<K> BlackBoard<K> {
+    pub fn get_db(&mut self) -> &mut K {
         &mut self.0
     }
 }
@@ -27,21 +26,21 @@ impl<K, V> BlackBoard<K, V> {
 /// The BT struct contains a compiled (immutable) version
 /// of the behavior and a blackboard key/value storage
 #[derive(Clone, Debug)]
-pub struct BT<A, K, V> {
+pub struct BT<A, K> {
     /// constructed behavior tree
     pub state: State<A>,
     /// keep the initial state
     initial_behavior: Behavior<A>,
     /// blackboard
-    bb: BlackBoard<K, V>,
+    bb: BlackBoard<K>,
     /// Tree formulated as PetGraph
     pub(crate) graph: Graph<NodeType<A>, u32, petgraph::Directed>,
     /// root node
     root_id: NodeIndex,
 }
 
-impl<A: Clone + Debug, K: Debug, V: Debug> BT<A, K, V> {
-    pub fn new(behavior: Behavior<A>, blackboard: HashMap<K, V>) -> Self {
+impl<A: Clone + Debug, K: Debug> BT<A, K> {
+    pub fn new(behavior: Behavior<A>, blackboard: K) -> Self {
         let backup_behavior = behavior.clone();
         let bt = State::new(behavior);
 
@@ -96,13 +95,13 @@ impl<A: Clone + Debug, K: Debug, V: Debug> BT<A, K, V> {
 
     /// Retrieve a mutable reference to the blackboard for
     /// this Behavior Tree
-    pub fn get_blackboard(&mut self) -> &mut BlackBoard<K, V> {
+    pub fn get_blackboard(&mut self) -> &mut BlackBoard<K> {
         &mut self.bb
     }
 
     /// Retrieve a mutable reference to the internal state
     /// of the Behavior Tree
-    pub fn get_state(bt: &mut BT<A, K, V>) -> &mut State<A> {
+    pub fn get_state(bt: &mut BT<A, K>) -> &mut State<A> {
         &mut bt.state
     }
 

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -57,6 +57,18 @@ impl<A: Clone + Debug, K: Debug> BT<A, K> {
         }
     }
 
+    /// Updates the cursor that tracks an event.
+    ///
+    /// The action need to return status and remaining delta time.
+    /// Returns status and the remaining delta time.
+    ///
+    /// Passes event, delta time in seconds, action and state to closure.
+    /// The closure should return a status and remaining delta time.
+    ///
+    /// return: (Status, f64)
+    /// function returns the result of the tree traversal, and how long
+    /// it actually took to complete the traversal and propagate the
+    /// results back up to the root node
     #[inline]
     pub fn tick<E, F>(&mut self, e: &E, f: &mut F) -> (Status, f64)
     where

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -57,6 +57,7 @@ impl<A: Clone + Debug, K: Debug> BT<A, K> {
         }
     }
 
+    #[inline]
     pub fn tick<E, F>(&mut self, e: &E, f: &mut F) -> (Status, f64)
     where
         E: UpdateEvent,

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! ```rust
 //! use bonsai_bt::{Event, Success, UpdateArgs, BT};
-//!
+//! use std::collections::HashMap;
 //! // Some test actions.
 //! #[derive(Clone, Debug, Copy)]
 //! pub enum Actions {
@@ -48,8 +48,8 @@
 //! }
 //!
 //! // A test state machine that can increment and decrement.
-//! fn tick(mut acc: i32, dt: f64, bt: &mut BT<Actions, String, i32>) -> i32 {
-//!     let e: Event = UpdateArgs { dt }.into();
+//! fn tick(mut acc: i32, dt: f64, bt: &mut BT<Actions, HashMap<String, i32>>) -> i32 {
+//! let e: Event = UpdateArgs { dt }.into();
 //!
 //!     let (_status, _dt) = bt.state.tick(&e, &mut |args| match *args.action {
 //!         Actions::Inc => {

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -51,7 +51,7 @@
 //! fn tick(mut acc: i32, dt: f64, bt: &mut BT<Actions, HashMap<String, i32>>) -> i32 {
 //! let e: Event = UpdateArgs { dt }.into();
 //!
-//!     let (_status, _dt) = bt.state.tick(&e, &mut |args| match *args.action {
+//!     let (_status, _dt) = bt.tick(&e, &mut |args, blackboard| match *args.action {
 //!         Actions::Inc => {
 //!             acc += 1;
 //!             (Success, args.dt)

--- a/bonsai/src/sequence.rs
+++ b/bonsai/src/sequence.rs
@@ -1,28 +1,39 @@
 use crate::status::Status::*;
 use crate::{event::UpdateEvent, ActionArgs, Behavior, State, Status, RUNNING};
 use std::fmt::Debug;
+pub struct SequenceArgs<'a, A, E, F, B> {
+    pub select: bool,
+    pub upd: Option<f64>,
+    pub seq: &'a [Behavior<A>],
+    pub i: &'a mut usize,
+    pub cursor: &'a mut Box<State<A>>,
+    pub e: &'a E,
+    pub blackboard: &'a mut B,
+    pub f: &'a mut F,
+}
 
-// type TickClosure<E,A, B> = dyn FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64);
 // `Sequence` and `Select` share same algorithm.
 //
 // `Sequence` fails if any fails and succeeds when all succeeds.
 // `Select` succeeds if any succeeds and fails when all fails.
-pub fn sequence<A, E, F, B>(
-    select: bool,
-    upd: Option<f64>,
-    seq: &[Behavior<A>],
-    i: &mut usize,
-    cursor: &mut Box<State<A>>,
-    e: &E,
-    f: &mut F,
-    blackboard: &mut B,
-) -> (Status, f64)
+pub fn sequence<A, E, F, B>(args: SequenceArgs<A, E, F, B>) -> (Status, f64)
 where
     A: Clone,
     E: UpdateEvent,
     F: FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64),
     A: Debug,
 {
+    let SequenceArgs {
+        select,
+        upd,
+        seq,
+        i,
+        cursor,
+        e,
+        blackboard,
+        f,
+    } = args;
+
     let (status, inv_status) = if select {
         // `Select`
         (Status::Failure, Status::Success)

--- a/bonsai/src/sequence.rs
+++ b/bonsai/src/sequence.rs
@@ -2,11 +2,12 @@ use crate::status::Status::*;
 use crate::{event::UpdateEvent, ActionArgs, Behavior, State, Status, RUNNING};
 use std::fmt::Debug;
 
+// type TickClosure<E,A, B> = dyn FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64);
 // `Sequence` and `Select` share same algorithm.
 //
 // `Sequence` fails if any fails and succeeds when all succeeds.
 // `Select` succeeds if any succeeds and fails when all fails.
-pub fn sequence<A, E, F>(
+pub fn sequence<A, E, F, B>(
     select: bool,
     upd: Option<f64>,
     seq: &[Behavior<A>],
@@ -14,11 +15,12 @@ pub fn sequence<A, E, F>(
     cursor: &mut Box<State<A>>,
     e: &E,
     f: &mut F,
+    blackboard: &mut B,
 ) -> (Status, f64)
 where
     A: Clone,
     E: UpdateEvent,
-    F: FnMut(ActionArgs<E, A>) -> (Status, f64),
+    F: FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64),
     A: Debug,
 {
     let (status, inv_status) = if select {
@@ -39,6 +41,7 @@ where
                 }
                 _ => e,
             },
+            blackboard,
             f,
         ) {
             (Running, _) => {

--- a/bonsai/src/sequence.rs
+++ b/bonsai/src/sequence.rs
@@ -1,7 +1,7 @@
 use crate::status::Status::*;
 use crate::{event::UpdateEvent, ActionArgs, Behavior, State, Status, RUNNING};
 use std::fmt::Debug;
-pub struct SequenceArgs<'a, A, E, F, B> {
+pub(crate) struct SequenceArgs<'a, A, E, F, B> {
     pub select: bool,
     pub upd: Option<f64>,
     pub seq: &'a [Behavior<A>],

--- a/bonsai/src/state.rs
+++ b/bonsai/src/state.rs
@@ -1,11 +1,12 @@
-use crate::bt::BlackBoard;
+use std::fmt::Debug;
+
 use crate::event::UpdateEvent;
-use crate::sequence::sequence;
+use crate::sequence::{sequence, SequenceArgs};
 use crate::state::State::*;
 use crate::status::Status::*;
 use crate::when_all::when_all;
 use crate::{Behavior, Status};
-use std::fmt::Debug;
+
 // use serde_derive::{Deserialize, Serialize};
 
 /// The action is still running, and thus the action consumes
@@ -208,12 +209,30 @@ impl<A: Clone> State<A> {
             (_, &mut SelectState(ref seq, ref mut i, ref mut cursor)) => {
                 // println!("In SelectState: {:?}", seq);
                 let select = true;
-                sequence(select, upd, seq, i, cursor, e, f, blackboard)
+                sequence(SequenceArgs {
+                    select,
+                    upd,
+                    seq,
+                    i,
+                    cursor,
+                    e,
+                    f,
+                    blackboard,
+                })
             }
             (_, &mut SequenceState(ref seq, ref mut i, ref mut cursor)) => {
                 // println!("In SequenceState: {:?}", seq);
                 let select = false;
-                sequence(select, upd, seq, i, cursor, e, f, blackboard)
+                sequence(SequenceArgs {
+                    select,
+                    upd,
+                    seq,
+                    i,
+                    cursor,
+                    e,
+                    f,
+                    blackboard,
+                })
             }
             (_, &mut WhileState(ref mut ev_cursor, ref rep, ref mut i, ref mut cursor)) => {
                 // println!("In WhileState: {:?}", ev_cursor);

--- a/bonsai/src/visualizer.rs
+++ b/bonsai/src/visualizer.rs
@@ -128,12 +128,13 @@ impl<A: Clone + Debug, K: Debug> BT<A, K> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bt::BlackBoard;
     use crate::visualizer::tests::TestActions::{Dec, Inc};
     use crate::Behavior::{
         Action, After, AlwaysSucceed, If, Invert, Select, Sequence, Wait, WaitForever, WhenAll, WhenAny, While,
     };
     use crate::Status::{self, Success};
-    use crate::{Event, UpdateArgs};
+    use crate::{ActionArgs, Event, UpdateArgs};
     use petgraph::dot::{Config, Dot};
     use petgraph::Graph;
     use std::collections::HashMap;
@@ -150,7 +151,7 @@ mod tests {
     // A test state machine that can increment and decrement.
     fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> (i32, Status, f64) {
         let e: Event = UpdateArgs { dt }.into();
-        let (s, t) = bt.state.tick(&e, &mut |args| match args.action {
+        let (s, t) = bt.tick(&e, &mut |args, blackboard| match args.action {
             TestActions::Inc => {
                 acc += 1;
                 (Success, args.dt)

--- a/bonsai/src/visualizer.rs
+++ b/bonsai/src/visualizer.rs
@@ -21,7 +21,7 @@ pub(crate) enum NodeType<A> {
     After,
 }
 
-impl<A: Clone + Debug, K: Debug, V: Debug> BT<A, K, V> {
+impl<A: Clone + Debug, K: Debug> BT<A, K> {
     pub(crate) fn dfs_recursive(&mut self, behavior: Behavior<A>, parent_node: NodeIndex) {
         match behavior {
             Behavior::Action(action) => {
@@ -148,7 +148,7 @@ mod tests {
     }
 
     // A test state machine that can increment and decrement.
-    fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, String, i32>) -> (i32, Status, f64) {
+    fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> (i32, Status, f64) {
         let e: Event = UpdateArgs { dt }.into();
         let (s, t) = bt.state.tick(&e, &mut |args| match args.action {
             TestActions::Inc => {

--- a/bonsai/src/when_all.rs
+++ b/bonsai/src/when_all.rs
@@ -7,17 +7,18 @@ use std::fmt::Debug;
 // `WhenAll` fails if any fails and succeeds when all succeeds.
 // `WhenAny` succeeds if any succeeds and fails when all fails.
 #[rustfmt::skip]
-pub fn when_all<A, E, F>(
+pub fn when_all<A, E, F, B>(
     any: bool,
     upd: Option<f64>,
     cursors: &mut [Option<State<A>>],
     e: &E,
     f: &mut F,
+    blackboard: &mut B,
 ) -> (Status, f64)
 where
     A: Clone,
     E: UpdateEvent,
-    F: FnMut(ActionArgs<E, A>) -> (Status, f64),
+    F: FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64),
     A: Debug,
 {
     let (status, inv_status) = if any {
@@ -35,7 +36,7 @@ where
         match *cur {
             None => {}
             Some(ref mut cur) => {
-                match cur.tick(e, f) {
+                match cur.tick(e, blackboard, f) {
                     (Running, _) => {
                         continue;
                     }

--- a/bonsai/tests/behavior_tests.rs
+++ b/bonsai/tests/behavior_tests.rs
@@ -68,7 +68,6 @@ fn tick(mut acc: i32, dt: f64, state: &mut State<TestActions>) -> (i32, bonsai_b
 fn tick_with_ref(acc: &mut i32, dt: f64, state: &mut State<TestActions>) {
     let e: Event = UpdateArgs { dt }.into();
 
-    // state.tick(&e, &mut |args| match *args.action {
     state.tick(
         &e,
         &mut (),

--- a/bonsai/tests/blackboard_tests.rs
+++ b/bonsai/tests/blackboard_tests.rs
@@ -13,7 +13,7 @@ pub enum TestActions {
 }
 
 // A test state machine that can increment and decrement.
-fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, String, i32>) -> i32 {
+fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> i32 {
     let e: Event = UpdateArgs { dt }.into();
 
     let (_s, _t) = bt.state.tick(&e, &mut |args| match *args.action {

--- a/bonsai/tests/blackboard_tests.rs
+++ b/bonsai/tests/blackboard_tests.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
-use crate::blackboard_tests::TestActions::{Dec, Inc};
 use bonsai_bt::{Action, Event, Sequence, Success, UpdateArgs, Wait, BT};
+
+use crate::blackboard_tests::TestActions::{Dec, Inc};
 
 /// Some test actions.
 #[derive(Clone, Debug, Copy)]
@@ -16,7 +17,7 @@ pub enum TestActions {
 fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> i32 {
     let e: Event = UpdateArgs { dt }.into();
 
-    let (_s, _t) = bt.state.tick(&e, &mut |args| match *args.action {
+    let (_s, _t) = bt.tick(&e, &mut |args, _| match *args.action {
         Inc => {
             acc += 1;
             (Success, args.dt)

--- a/bonsai/tests/bt_tests.rs
+++ b/bonsai/tests/bt_tests.rs
@@ -18,7 +18,7 @@ enum TestActions {
 fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> (i32, bonsai_bt::Status, f64) {
     let e: Event = UpdateArgs { dt }.into();
     println!("acc {}", acc);
-    let (s, t) = bt.state.tick(&e, &mut |args| match *args.action {
+    let (s, t) = bt.tick(&e, &mut |args, _| match *args.action {
         Inc => {
             acc += 1;
             (Success, args.dt)

--- a/bonsai/tests/bt_tests.rs
+++ b/bonsai/tests/bt_tests.rs
@@ -15,7 +15,7 @@ enum TestActions {
 }
 
 // A test state machine that can increment and decrement.
-fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, String, i32>) -> (i32, bonsai_bt::Status, f64) {
+fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> (i32, bonsai_bt::Status, f64) {
     let e: Event = UpdateArgs { dt }.into();
     println!("acc {}", acc);
     let (s, t) = bt.state.tick(&e, &mut |args| match *args.action {

--- a/bonsai/tests/dynamic_behavior_tests.rs
+++ b/bonsai/tests/dynamic_behavior_tests.rs
@@ -15,7 +15,6 @@ enum TestActions {
 fn tick(mut acc: usize, dt: f64, t: &mut f64, counter: &mut usize, state: &mut State<TestActions>) -> usize {
     let e: Event = UpdateArgs { dt }.into();
 
-    // let (_s, _t) = state.tick(&e, &mut |args| match args.action {
     let (_s, _t) = state.tick(
         &e,
         &mut (),

--- a/examples/src/3d/main.rs
+++ b/examples/src/3d/main.rs
@@ -76,7 +76,7 @@ fn game_tick(
     w: &mut Window,
     mut events: EventManager,
     timer: &mut Timer,
-    bt: &mut BT<Animation, String, serde_json::Value>,
+    bt: &mut BT<Animation, HashMap<String, serde_json::Value>>,
 ) {
     // timer since bt was first invoked
     let t = timer.duration_since_start();

--- a/examples/src/3d/main.rs
+++ b/examples/src/3d/main.rs
@@ -94,7 +94,7 @@ fn game_tick(
     let mut last_pos = mouse_pos(0.0, 0.0);
     // update state of behaviosuccessr tree
     #[rustfmt::skip]
-    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Animation>, blackboard|
+    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Animation>, _|
         match *args.action {
             Animation::LongerThan(dur) => {
                 if t > dur {

--- a/examples/src/3d/main.rs
+++ b/examples/src/3d/main.rs
@@ -94,7 +94,7 @@ fn game_tick(
     let mut last_pos = mouse_pos(0.0, 0.0);
     // update state of behaviosuccessr tree
     #[rustfmt::skip]
-    bt.state.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Animation>|
+    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Animation>, blackboard|
         match *args.action {
             Animation::LongerThan(dur) => {
                 if t > dur {

--- a/examples/src/async_drone/main.rs
+++ b/examples/src/async_drone/main.rs
@@ -5,6 +5,7 @@ use bonsai_bt::{
 };
 use futures::FutureExt;
 use jobs::{collision_avoidance_task, landing_task, takeoff_task};
+use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver};
 
 use crate::jobs::{fly_to_point_task, Point};
@@ -36,7 +37,7 @@ pub struct DroneState {
 async fn drone_tick(
     timer: &mut Timer,
     drone_state: &mut DroneState,
-    bt: &mut BT<DroneAction, String, serde_json::Value>,
+    bt: &mut BT<DroneAction, HashMap<String, serde_json::Value>>,
 ) {
     // timer since bt was first invoked
     let _t = timer.duration_since_start();

--- a/examples/src/async_drone/main.rs
+++ b/examples/src/async_drone/main.rs
@@ -50,7 +50,7 @@ async fn drone_tick(
 
     // update state of behaviosuccessr tree
     #[rustfmt::skip]
-    bt.state.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, DroneAction>|
+    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, DroneAction>, blackboard|
         match *args.action {
             DroneAction::AvoidOthers => {
                 let avoid_state = &drone_state.avoid_others;

--- a/examples/src/async_drone/main.rs
+++ b/examples/src/async_drone/main.rs
@@ -50,7 +50,7 @@ async fn drone_tick(
 
     // update state of behaviosuccessr tree
     #[rustfmt::skip]
-    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, DroneAction>, blackboard|
+    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, DroneAction>, _|
         match *args.action {
             DroneAction::AvoidOthers => {
                 let avoid_state = &drone_state.avoid_others;

--- a/examples/src/boids/boid.rs
+++ b/examples/src/boids/boid.rs
@@ -1,5 +1,6 @@
 use bonsai_bt::{Event, Status::Success, UpdateArgs, BT, RUNNING};
 use ggez::mint;
+use std::collections::HashMap;
 
 //algorithm stuff
 const SPEED_LIMIT: f32 = 400.0; // Pixels per second
@@ -27,11 +28,11 @@ pub struct Boid {
     pub dx: f32,
     pub dy: f32,
     pub color: [f32; 4],
-    pub bt: BT<Action, String, f32>,
+    pub bt: BT<Action, HashMap<String, f32>>,
 }
 
 impl Boid {
-    pub fn new(win_width: f32, win_height: f32, bt: BT<Action, String, f32>) -> Boid {
+    pub fn new(win_width: f32, win_height: f32, bt: BT<Action, HashMap<String, f32>>) -> Boid {
         Boid {
             x: (rand::random::<f32>() * win_width / 2.0 + win_width / 4.0),
             y: (rand::random::<f32>() * win_height / 2.0 + win_height / 4.0),

--- a/examples/src/boids/boid.rs
+++ b/examples/src/boids/boid.rs
@@ -65,7 +65,7 @@ pub fn game_tick(dt: f32, cursor: mint::Point2<f32>, boid: &mut Boid, other_boid
     let win_height: f32 = *db.get("win_height").unwrap();
 
     #[rustfmt::skip]
-    bt.state.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Action>| {
+    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Action>, blackboard| {
         match args.action {
             Action::AvoidOthers => {
                 let avoid_factor = 0.5;

--- a/examples/src/boids/boid.rs
+++ b/examples/src/boids/boid.rs
@@ -65,7 +65,7 @@ pub fn game_tick(dt: f32, cursor: mint::Point2<f32>, boid: &mut Boid, other_boid
     let win_height: f32 = *db.get("win_height").unwrap();
 
     #[rustfmt::skip]
-    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Action>, blackboard| {
+    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Action>, _| {
         match args.action {
             Action::AvoidOthers => {
                 let avoid_factor = 0.5;

--- a/examples/src/boids/main.rs
+++ b/examples/src/boids/main.rs
@@ -3,6 +3,7 @@ mod boid;
 use boid::{game_tick, Action};
 use bonsai_bt::BT;
 use ggez::{conf, event, graphics, input, timer, Context, ContextBuilder, GameResult};
+use std::collections::HashMap;
 
 //window stuff
 const HEIGHT: f32 = 720.0;
@@ -13,7 +14,7 @@ const NUM_BOIDS: usize = 100; // n
 const BOID_SIZE: f32 = 32.0; // Pixels
 
 // generate boids
-fn get_boids(bt: &BT<Action, String, f32>) -> Vec<boid::Boid> {
+fn get_boids(bt: &BT<Action, HashMap<String, f32>>) -> Vec<boid::Boid> {
     std::iter::repeat_with(|| boid::Boid::new(WIDTH, HEIGHT, bt.clone()))
         .take(NUM_BOIDS)
         .collect()
@@ -30,11 +31,11 @@ struct GameState {
     dt: std::time::Duration,
     boids: Vec<boid::Boid>,
     points: Vec<glam::Vec2>,
-    bt: BT<Action, String, f32>,
+    bt: BT<Action, HashMap<String, f32>>,
 }
 
 impl GameState {
-    pub fn new(_ctx: &mut Context, bt: BT<Action, String, f32>) -> GameState {
+    pub fn new(_ctx: &mut Context, bt: BT<Action, HashMap<String, f32>>) -> GameState {
         GameState {
             state: PlayState::Setup,
             dt: std::time::Duration::new(0, 0),
@@ -162,7 +163,6 @@ impl event::EventHandler for GameState {
 
 fn main() {
     use bonsai_bt::{Action, WhenAll, While};
-    use std::collections::HashMap;
     let (mut ctx, events_loop) = ContextBuilder::new("Boids", "Daniel Eisen")
         .window_mode(conf::WindowMode::default().dimensions(WIDTH, HEIGHT))
         .window_setup(conf::WindowSetup::default().samples(conf::NumSamples::Eight))

--- a/examples/src/simple_npc_ai/main.rs
+++ b/examples/src/simple_npc_ai/main.rs
@@ -19,8 +19,6 @@ fn game_tick(bt: &mut BT<EnemyNPC, BlackBoardData>, state: &mut EnemyNPCState) -
         match *args.action {
             EnemyNPC::Run => {
                 state.perform_action("run");
-
-
                 (Success, 0.0)
             },
             EnemyNPC::HasActionPointsLeft => {

--- a/examples/src/simple_npc_ai/main.rs
+++ b/examples/src/simple_npc_ai/main.rs
@@ -15,7 +15,7 @@ fn game_tick(bt: &mut BT<EnemyNPC, BlackBoardData>, state: &mut EnemyNPCState) -
     let e: Event = UpdateArgs { dt: 0.0 }.into();
 
     #[rustfmt::skip]
-    let status = bt.state.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, EnemyNPC>| {
+    let status = bt.tick(&e, &mut |args: bonsai_bt::ActionArgs<Event, EnemyNPC>, blackboard| {
         match *args.action {
             EnemyNPC::Run => {
                 state.perform_action("run");
@@ -40,8 +40,8 @@ fn game_tick(bt: &mut BT<EnemyNPC, BlackBoardData>, state: &mut EnemyNPCState) -
                 // one of its values here:
 
                 // second mutable borrow:
-                // let mut blackboard = bt.get_blackboard().get_db();
-                // blackboard.times_shot += 1;
+                let mut blackboard = blackboard.get_db();
+                blackboard.times_shot += 1;
 
                 (Success, 0.0)
             }

--- a/examples/src/simple_npc_ai/main.rs
+++ b/examples/src/simple_npc_ai/main.rs
@@ -38,8 +38,10 @@ fn game_tick(bt: &mut BT<EnemyNPC, BlackBoardData>, state: &mut EnemyNPCState) -
 
                 // for the sake of example we get access blackboard and update
                 // one of its values here:
-                //let mut blackboard = args.get_blackboard().get_db();
-                //blackboard.times_shot += 1;
+
+                // second mutable borrow:
+                // let mut blackboard = bt.get_blackboard().get_db();
+                // blackboard.times_shot += 1;
 
                 (Success, 0.0)
             }

--- a/examples/src/simple_npc_ai/main.rs
+++ b/examples/src/simple_npc_ai/main.rs
@@ -36,7 +36,7 @@ fn game_tick(bt: &mut BT<EnemyNPC, BlackBoardData>, state: &mut EnemyNPCState) -
             EnemyNPC::Shoot => {
                 state.perform_action("shoot");
 
-                // for the sake of example we get access blackboard and update
+                // for the sake of example we get access to blackboard and update
                 // one of its values here:
                 blackboard.get_db().times_shot += 1;
 

--- a/examples/src/simple_npc_ai/main.rs
+++ b/examples/src/simple_npc_ai/main.rs
@@ -38,10 +38,7 @@ fn game_tick(bt: &mut BT<EnemyNPC, BlackBoardData>, state: &mut EnemyNPCState) -
 
                 // for the sake of example we get access blackboard and update
                 // one of its values here:
-
-                // second mutable borrow:
-                let mut blackboard = blackboard.get_db();
-                blackboard.times_shot += 1;
+                blackboard.get_db().times_shot += 1;
 
                 (Success, 0.0)
             }


### PR DESCRIPTION
Generalize blackboard. 

From user's perspective, in addition to being able to use generic blackboard type, the user must now use tick directly with `bt.tick(...)` instead of `bt.state.tick(...)` This change is required so that we can pass a mutable reference of the blackboard to the user's tick callback under the hood.