### PR TITLE
Delete `BlackBoard` struct.

### DIFF
--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -12,7 +12,7 @@ name = "bonsai-bt"
 readme = "../README.md"
 repository = "https://github.com/sollimann/bonsai.git"
 rust-version = "1.80.0"
-version = "0.8.1"
+version = "0.9.0"
 
 [lib]
 name = "bonsai_bt"
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 petgraph = "0.6.2"
-serde = { version = "1.0.137", features = ["derive"] , optional = true }
+serde = { version = "1.0.137", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0.81" }

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -12,17 +12,17 @@ use serde::{Deserialize, Serialize};
 /// of the behavior and a blackboard key/value storage
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct BT<A, K> {
+pub struct BT<A, B> {
     /// constructed behavior tree
     pub state: State<A>,
     /// keep the initial state
     initial_behavior: Behavior<A>,
     /// blackboard
-    bb: K,
+    bb: B,
 }
 
-impl<A: Clone, K> BT<A, K> {
-    pub fn new(behavior: Behavior<A>, blackboard: K) -> Self {
+impl<A: Clone, B> BT<A, B> {
+    pub fn new(behavior: Behavior<A>, blackboard: B) -> Self {
         let backup_behavior = behavior.clone();
         let bt = State::new(behavior);
 
@@ -49,20 +49,20 @@ impl<A: Clone, K> BT<A, K> {
     pub fn tick<E, F>(&mut self, e: &E, f: &mut F) -> (Status, f64)
     where
         E: UpdateEvent,
-        F: FnMut(ActionArgs<E, A>, &mut K) -> (Status, f64),
+        F: FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64),
     {
         self.state.tick(e, &mut self.bb, f)
     }
 
     /// Retrieve a mutable reference to the blackboard for
     /// this Behavior Tree
-    pub fn get_blackboard(&mut self) -> &mut K {
+    pub fn get_blackboard(&mut self) -> &mut B {
         &mut self.bb
     }
 
     /// Retrieve a mutable reference to the internal state
     /// of the Behavior Tree
-    pub fn get_state(bt: &mut BT<A, K>) -> &mut State<A> {
+    pub fn get_state(bt: &mut BT<A, B>) -> &mut State<A> {
         &mut bt.state
     }
 
@@ -83,7 +83,7 @@ impl<A: Clone, K> BT<A, K> {
     }
 }
 
-impl<A: Clone + Debug, K: Debug> BT<A, K> {
+impl<A: Clone + Debug, B: Debug> BT<A, B> {
     /// Compile the behavior tree into a [graphviz](https://graphviz.org/) compatible [DiGraph](https://docs.rs/petgraph/latest/petgraph/graph/type.DiGraph.html).
     ///
     /// ```rust

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -8,8 +8,8 @@ use petgraph::Graph;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// The BT struct contains a compiled (immutable) version
-/// of the behavior and a blackboard key/value storage
+/// The execution state of a behavior tree, along with a "blackboard" (state
+/// shared between all nodes in the tree).
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BT<A, B> {
@@ -17,7 +17,9 @@ pub struct BT<A, B> {
     pub state: State<A>,
     /// keep the initial state
     initial_behavior: Behavior<A>,
-    /// blackboard
+    /// The data storage shared by all nodes in the tree. This is generally
+    /// referred to as a "blackboard". State is written to and read from a
+    /// blackboard, allowing nodes to share state and communicate each other.
     bb: B,
 }
 

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -65,8 +65,7 @@
 //!     // update counter in blackboard
 //!     let bb = bt.get_blackboard();
 //!
-//!     bb.get_db()
-//!         .entry("count".to_string())
+//!     bb.entry("count".to_string())
 //!         .and_modify(|count| *count = acc)
 //!         .or_insert(0)
 //!         .to_owned();
@@ -109,7 +108,7 @@
 //!     assert_eq!(a, 1);
 //!
 //!     let bb = bt.get_blackboard();
-//!     let count = bb.get_db().get("count").unwrap();
+//!     let count = bb.get("count").unwrap();
 //!     assert_eq!(*count, 1);
 //!
 //!     // if the behavior tree concludes (reaches a steady state)

--- a/bonsai/src/visualizer.rs
+++ b/bonsai/src/visualizer.rs
@@ -132,7 +132,6 @@ impl<A: Clone + Debug, K: Debug> BT<A, K> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bt::BlackBoard;
     use crate::visualizer::tests::TestActions::{Dec, Inc};
     use crate::Behavior::{
         Action, After, AlwaysSucceed, If, Invert, Select, Sequence, Wait, WaitForever, WhenAll, WhenAny, While,

--- a/bonsai/tests/blackboard_tests.rs
+++ b/bonsai/tests/blackboard_tests.rs
@@ -31,8 +31,7 @@ fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -
     // update counter in blackboard
     let bb = bt.get_blackboard();
 
-    bb.get_db()
-        .entry("count".to_string())
+    bb.entry("count".to_string())
         .and_modify(|count| *count = acc)
         .or_insert(0)
         .to_owned()
@@ -64,6 +63,6 @@ fn test_crate_bt() {
     assert_eq!(a, 1);
 
     let bb = bt.get_blackboard();
-    let count = bb.get_db().get("count").unwrap();
+    let count = bb.get("count").unwrap();
     assert_eq!(*count, 1);
 }

--- a/examples/src/3d/main.rs
+++ b/examples/src/3d/main.rs
@@ -90,7 +90,7 @@ fn game_tick(
     let e: Event = UpdateArgs { dt }.into();
 
     // get data from blackboard
-    let db = &*bt.get_blackboard().get_db();
+    let db = &*bt.get_blackboard();
     let inc: u64 = db.get("count").map_or(Some(0), |x| x.as_u64()).unwrap();
 
     let mut last_pos = mouse_pos(0.0, 0.0);
@@ -197,7 +197,7 @@ fn game_tick(
     );
 
     // update blackboard
-    let db = bt.get_blackboard().get_db();
+    let db = bt.get_blackboard();
 
     // update count
     let _count = db

--- a/examples/src/3d/main.rs
+++ b/examples/src/3d/main.rs
@@ -90,7 +90,7 @@ fn game_tick(
     let e: Event = UpdateArgs { dt }.into();
 
     // get data from blackboard
-    let db = &*bt.get_blackboard();
+    let db = bt.get_blackboard();
     let inc: u64 = db.get("count").map_or(Some(0), |x| x.as_u64()).unwrap();
 
     let mut last_pos = mouse_pos(0.0, 0.0);

--- a/examples/src/boids/boid.rs
+++ b/examples/src/boids/boid.rs
@@ -60,7 +60,7 @@ pub fn game_tick(dt: f32, cursor: mint::Point2<f32>, boid: &mut Boid, other_boid
 
     // unwrap bt for boid
     let mut bt = boid.bt.clone();
-    let db = &*bt.get_blackboard();
+    let db = bt.get_blackboard();
     let win_width: f32 = *db.get("win_width").unwrap();
     let win_height: f32 = *db.get("win_height").unwrap();
 

--- a/examples/src/boids/boid.rs
+++ b/examples/src/boids/boid.rs
@@ -60,7 +60,7 @@ pub fn game_tick(dt: f32, cursor: mint::Point2<f32>, boid: &mut Boid, other_boid
 
     // unwrap bt for boid
     let mut bt = boid.bt.clone();
-    let db = &*bt.get_blackboard().get_db();
+    let db = &*bt.get_blackboard();
     let win_width: f32 = *db.get("win_width").unwrap();
     let win_height: f32 = *db.get("win_height").unwrap();
 

--- a/examples/src/simple_npc_ai/main.rs
+++ b/examples/src/simple_npc_ai/main.rs
@@ -36,7 +36,7 @@ fn game_tick(bt: &mut BT<EnemyNPC, BlackBoardData>, state: &mut EnemyNPCState) -
 
                 // for the sake of example we get access to blackboard and update
                 // one of its values here:
-                blackboard.get_db().times_shot += 1;
+                blackboard.times_shot += 1;
 
                 (Success, 0.0)
             }
@@ -174,7 +174,7 @@ fn main() {
     }
     println!(
         "NPC shot {} times during the simulation.",
-        bt.get_blackboard().get_db().times_shot
+        bt.get_blackboard().times_shot
     );
 }
 


### PR DESCRIPTION
This struct doesn't do anything special and is just a newtype without providing anything. I believe in the past this did more, but now it is just a needless wrapper.