### PR TITLE
Move the action out of ActionArgs and directly into the tick FnMut.

### DIFF
--- a/bonsai/src/behavior.rs
+++ b/bonsai/src/behavior.rs
@@ -87,8 +87,8 @@ pub enum Behavior<A> {
     ///let mut bt = BT::new(rs, ());
     ///
     ///let mut i = 0;
-    ///let status = bt.tick(&Event::zero_dt_args(), &mut |args: ActionArgs<Event, Ex>, _| {
-    ///    match args.action {
+    ///let status = bt.tick(&Event::zero_dt_args(), &mut |action, _, _| {
+    ///    match action {
     ///        Ex::A => {
     ///            i += 1;
     ///            if i == 4 {

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -51,7 +51,7 @@ impl<A: Clone, B> BT<A, B> {
     pub fn tick<E, F>(&mut self, e: &E, f: &mut F) -> (Status, f64)
     where
         E: UpdateEvent,
-        F: FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64),
+        F: FnMut(&A, &mut B, ActionArgs<E>) -> (Status, f64),
     {
         self.state.tick(e, &mut self.bb, f)
     }

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -51,7 +51,7 @@
 //! fn tick(mut acc: i32, dt: f64, bt: &mut BT<Actions, HashMap<String, i32>>) -> i32 {
 //! let e: Event = UpdateArgs { dt }.into();
 //!
-//!     let (_status, _dt) = bt.tick(&e, &mut |args, blackboard| match *args.action {
+//!     let (_status, _dt) = bt.tick(&e, &mut |action, blackboard, args| match *action {
 //!         Actions::Inc => {
 //!             acc += 1;
 //!             (Success, args.dt)

--- a/bonsai/src/sequence.rs
+++ b/bonsai/src/sequence.rs
@@ -20,7 +20,7 @@ pub fn sequence<A, E, F, B>(args: SequenceArgs<A, E, F, B>) -> (Status, f64)
 where
     A: Clone,
     E: UpdateEvent,
-    F: FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64),
+    F: FnMut(&A, &mut B, ActionArgs<E>) -> (Status, f64),
 {
     let SequenceArgs {
         select,

--- a/bonsai/src/visualizer.rs
+++ b/bonsai/src/visualizer.rs
@@ -154,7 +154,7 @@ mod tests {
     // A test state machine that can increment and decrement.
     fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> (i32, Status, f64) {
         let e: Event = UpdateArgs { dt }.into();
-        let (s, t) = bt.tick(&e, &mut |args, blackboard| match args.action {
+        let (s, t) = bt.tick(&e, &mut |action, blackboard, args| match action {
             TestActions::Inc => {
                 acc += 1;
                 (Success, args.dt)

--- a/bonsai/src/when_all.rs
+++ b/bonsai/src/when_all.rs
@@ -17,7 +17,7 @@ pub fn when_all<A, E, F, B>(
 where
     A: Clone,
     E: UpdateEvent,
-    F: FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64),
+    F: FnMut(&A, &mut B, ActionArgs<E>) -> (Status, f64),
 {
     let (status, inv_status) = if any {
         // `WhenAny`

--- a/bonsai/tests/behavior_tests.rs
+++ b/bonsai/tests/behavior_tests.rs
@@ -21,40 +21,36 @@ enum TestActions {
 fn tick(mut acc: i32, dt: f64, state: &mut State<TestActions>) -> (i32, bonsai_bt::Status, f64) {
     let e: Event = UpdateArgs { dt }.into();
     println!("acc {}", acc);
-    let (s, t) = state.tick(
-        &e,
-        &mut (),
-        &mut |args: ActionArgs<Event, TestActions>, _| match *args.action {
-            Inc => {
-                acc += 1;
+    let (s, t) = state.tick(&e, &mut (), &mut |action, _, args: ActionArgs<Event>| match *action {
+        Inc => {
+            acc += 1;
+            (Success, args.dt)
+        }
+        Dec => {
+            acc -= 1;
+            (Success, args.dt)
+        }
+        LessThan(v) => {
+            println!("inside less than with acc: {}", acc);
+            if acc < v {
+                println!("success {}<{}", acc, v);
+                (Success, args.dt)
+            } else {
+                println!("failure {}>={}", acc, v);
+                (Failure, args.dt)
+            }
+        }
+        TestActions::LessThanRunningSuccess(v) => {
+            println!("inside LessThanRunningSuccess with acc: {}", acc);
+            if acc < v {
+                println!("success {}<{}", acc, v);
+                (Running, args.dt)
+            } else {
+                println!("failure {}>={}", acc, v);
                 (Success, args.dt)
             }
-            Dec => {
-                acc -= 1;
-                (Success, args.dt)
-            }
-            LessThan(v) => {
-                println!("inside less than with acc: {}", acc);
-                if acc < v {
-                    println!("success {}<{}", acc, v);
-                    (Success, args.dt)
-                } else {
-                    println!("failure {}>={}", acc, v);
-                    (Failure, args.dt)
-                }
-            }
-            TestActions::LessThanRunningSuccess(v) => {
-                println!("inside LessThanRunningSuccess with acc: {}", acc);
-                if acc < v {
-                    println!("success {}<{}", acc, v);
-                    (Running, args.dt)
-                } else {
-                    println!("failure {}>={}", acc, v);
-                    (Success, args.dt)
-                }
-            }
-        },
-    );
+        }
+    });
     println!("status: {:?} dt: {}", s, t);
 
     (acc, s, t)
@@ -64,21 +60,17 @@ fn tick(mut acc: i32, dt: f64, state: &mut State<TestActions>) -> (i32, bonsai_b
 fn tick_with_ref(acc: &mut i32, dt: f64, state: &mut State<TestActions>) {
     let e: Event = UpdateArgs { dt }.into();
 
-    state.tick(
-        &e,
-        &mut (),
-        &mut |args: ActionArgs<Event, TestActions>, _| match *args.action {
-            Inc => {
-                *acc += 1;
-                (Success, args.dt)
-            }
-            Dec => {
-                *acc -= 1;
-                (Success, args.dt)
-            }
-            TestActions::LessThanRunningSuccess(_) | LessThan(_) => todo!(),
-        },
-    );
+    state.tick(&e, &mut (), &mut |action, _, args: ActionArgs<Event>| match *action {
+        Inc => {
+            *acc += 1;
+            (Success, args.dt)
+        }
+        Dec => {
+            *acc -= 1;
+            (Success, args.dt)
+        }
+        TestActions::LessThanRunningSuccess(_) | LessThan(_) => todo!(),
+    });
 }
 
 // Each action that terminates immediately

--- a/bonsai/tests/blackboard_tests.rs
+++ b/bonsai/tests/blackboard_tests.rs
@@ -17,7 +17,7 @@ pub enum TestActions {
 fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> i32 {
     let e: Event = UpdateArgs { dt }.into();
 
-    let (_s, _t) = bt.tick(&e, &mut |args, _| match *args.action {
+    let (_s, _t) = bt.tick(&e, &mut |action, _, args| match *action {
         Inc => {
             acc += 1;
             (Success, args.dt)

--- a/bonsai/tests/bt_tests.rs
+++ b/bonsai/tests/bt_tests.rs
@@ -18,7 +18,7 @@ enum TestActions {
 fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> (i32, bonsai_bt::Status, f64) {
     let e: Event = UpdateArgs { dt }.into();
     println!("acc {}", acc);
-    let (s, t) = bt.tick(&e, &mut |args, _| match *args.action {
+    let (s, t) = bt.tick(&e, &mut |action, _, args| match *action {
         Inc => {
             acc += 1;
             (Success, args.dt)

--- a/bonsai/tests/dynamic_behavior_tests.rs
+++ b/bonsai/tests/dynamic_behavior_tests.rs
@@ -15,34 +15,30 @@ enum TestActions {
 fn tick(mut acc: usize, dt: f64, t: &mut f64, counter: &mut usize, state: &mut State<TestActions>) -> usize {
     let e: Event = UpdateArgs { dt }.into();
 
-    let (_s, _t) = state.tick(
-        &e,
-        &mut (),
-        &mut |args: ActionArgs<Event, TestActions>, _| match args.action {
-            Inc => {
-                acc += 1;
-                (Success, args.dt)
+    let (_s, _t) = state.tick(&e, &mut (), &mut |action, _, args: ActionArgs<Event>| match action {
+        Inc => {
+            acc += 1;
+            (Success, args.dt)
+        }
+        DynamicWait(times) => {
+            // reset dynamic timer
+            if *counter >= times.len() {
+                *counter = 0
             }
-            DynamicWait(times) => {
-                // reset dynamic timer
-                if *counter >= times.len() {
-                    *counter = 0
-                }
 
-                let wait_t = times[counter.to_owned()];
+            let wait_t = times[counter.to_owned()];
 
-                if *t + dt >= wait_t {
-                    let time_overdue = *t + dt - wait_t;
-                    *counter += 1;
-                    *t = -dt;
-                    (Success, time_overdue)
-                } else {
-                    *t += dt;
-                    RUNNING
-                }
+            if *t + dt >= wait_t {
+                let time_overdue = *t + dt - wait_t;
+                *counter += 1;
+                *t = -dt;
+                (Success, time_overdue)
+            } else {
+                *t += dt;
+                RUNNING
             }
-        },
-    );
+        }
+    });
 
     acc
 }

--- a/examples/src/3d/main.rs
+++ b/examples/src/3d/main.rs
@@ -96,8 +96,8 @@ fn game_tick(
     let mut last_pos = mouse_pos(0.0, 0.0);
     // update state of behaviosuccessr tree
     #[rustfmt::skip]
-    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Animation>, _|
-        match *args.action {
+    bt.tick(&e,&mut |action, _, args: bonsai_bt::ActionArgs<Event>|
+        match *action {
             Animation::LongerThan(dur) => {
                 if t > dur {
                     (Status::Success, args.dt)

--- a/examples/src/async_drone/main.rs
+++ b/examples/src/async_drone/main.rs
@@ -50,8 +50,8 @@ async fn drone_tick(
 
     // update state of behaviosuccessr tree
     #[rustfmt::skip]
-    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, DroneAction>, _|
-        match *args.action {
+    bt.tick(&e,&mut |action, _, args: bonsai_bt::ActionArgs<Event>|
+        match *action {
             DroneAction::AvoidOthers => {
                 let avoid_state = &drone_state.avoid_others;
                 if let Some(avoid_status) = avoid_state {

--- a/examples/src/boids/boid.rs
+++ b/examples/src/boids/boid.rs
@@ -65,8 +65,8 @@ pub fn game_tick(dt: f32, cursor: mint::Point2<f32>, boid: &mut Boid, other_boid
     let win_height: f32 = *db.get("win_height").unwrap();
 
     #[rustfmt::skip]
-    bt.tick(&e,&mut |args: bonsai_bt::ActionArgs<Event, Action>, _| {
-        match args.action {
+    bt.tick(&e,&mut |action, _, args: bonsai_bt::ActionArgs<Event>| {
+        match action {
             Action::AvoidOthers => {
                 let avoid_factor = 0.5;
                 let mut move_x = 0.0;

--- a/examples/src/simple_npc_ai/main.rs
+++ b/examples/src/simple_npc_ai/main.rs
@@ -15,8 +15,8 @@ fn game_tick(bt: &mut BT<EnemyNPC, BlackBoardData>, state: &mut EnemyNPCState) -
     let e: Event = UpdateArgs { dt: 0.0 }.into();
 
     #[rustfmt::skip]
-    let status = bt.tick(&e, &mut |args: bonsai_bt::ActionArgs<Event, EnemyNPC>, blackboard| {
-        match *args.action {
+    let status = bt.tick(&e, &mut |action, blackboard, _| {
+        match *action {
             EnemyNPC::Run => {
                 state.perform_action("run");
                 (Success, 0.0)


### PR DESCRIPTION
This make it much more obvious what you're actually supposed to be doing in the tick FnMut. Instead of the action being hidden away, it is the first argument. Similarly, blackboard has been moved up since in many cases you don't need to deal with the event or the dt (just returning RUNNING or Success/Failure is good enough).