### PR TITLE
Reset `BT` if `tick` returns Success or Failure.

### DIFF
--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use crate::visualizer::NodeType;
-use crate::{ActionArgs, Behavior, State, Status, UpdateEvent};
+use crate::{state::State, ActionArgs, Behavior, Status, UpdateEvent};
 use petgraph::dot::{Config, Dot};
 use petgraph::Graph;
 
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BT<A, B> {
     /// constructed behavior tree
-    pub state: State<A>,
+    state: State<A>,
     /// keep the initial state
     initial_behavior: Behavior<A>,
     /// The data storage shared by all nodes in the tree. This is generally
@@ -60,12 +60,6 @@ impl<A: Clone, B> BT<A, B> {
     /// this Behavior Tree
     pub fn get_blackboard(&mut self) -> &mut B {
         &mut self.bb
-    }
-
-    /// Retrieve a mutable reference to the internal state
-    /// of the Behavior Tree
-    pub fn get_state(bt: &mut BT<A, B>) -> &mut State<A> {
-        &mut bt.state
     }
 
     /// The behavior tree is a stateful data structure in which the immediate

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -35,7 +35,8 @@ impl<A: Clone, B> BT<A, B> {
         }
     }
 
-    /// Updates the cursor that tracks an event.
+    /// Updates the cursor that tracks an event. If the behavior tree previously
+    /// finished (either success or failure), it will automatically be restarted.
     ///
     /// The action need to return status and remaining delta time.
     /// Returns status and the remaining delta time.
@@ -53,7 +54,13 @@ impl<A: Clone, B> BT<A, B> {
         E: UpdateEvent,
         F: FnMut(ActionArgs<E, A>, &mut B) -> (Status, f64),
     {
-        self.state.tick(e, &mut self.bb, f)
+        match self.state.tick(e, &mut self.bb, f) {
+            result @ (Status::Success | Status::Failure, _) => {
+                self.reset_bt();
+                result
+            }
+            result => result,
+        }
     }
 
     /// Retrieve a mutable reference to the blackboard for

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -124,7 +124,7 @@ pub use behavior::Behavior::{
 
 pub use bt::BT;
 pub use event::{Event, Timer, UpdateArgs, UpdateEvent};
-pub use state::{ActionArgs, State, RUNNING};
+pub use state::{ActionArgs, RUNNING};
 pub use status::Status::{self, Failure, Running, Success};
 
 mod behavior;

--- a/bonsai/src/sequence.rs
+++ b/bonsai/src/sequence.rs
@@ -1,5 +1,5 @@
 use crate::status::Status::*;
-use crate::{event::UpdateEvent, ActionArgs, Behavior, State, Status, RUNNING};
+use crate::{event::UpdateEvent, state::State, ActionArgs, Behavior, Status, RUNNING};
 
 pub struct SequenceArgs<'a, A, E, F, B> {
     pub select: bool,

--- a/bonsai/src/state.rs
+++ b/bonsai/src/state.rs
@@ -28,7 +28,7 @@ pub struct ActionArgs<'a, E: 'a, A: 'a> {
 /// Keeps track of a behavior.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum State<A> {
+pub(crate) enum State<A> {
     /// Executes an action.
     ActionState(A),
     /// Converts `Success` into `Failure` and vice versa.

--- a/bonsai/src/state.rs
+++ b/bonsai/src/state.rs
@@ -30,17 +30,17 @@ pub struct ActionArgs<'a, E: 'a, A: 'a> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub(crate) enum State<A> {
     /// Executes an action.
-    ActionState(A),
+    Action(A),
     /// Converts `Success` into `Failure` and vice versa.
-    InvertState(Box<State<A>>),
+    Invert(Box<State<A>>),
     /// Ignores failures and always return `Success`.
-    AlwaysSucceedState(Box<State<A>>),
+    AlwaysSucceed(Box<State<A>>),
     /// Keeps track of waiting for a period of time before continuing.
-    WaitState { time_to_wait: f64, elapsed_time: f64 },
+    Wait { time_to_wait: f64, elapsed_time: f64 },
     /// Waits forever.
-    WaitForeverState,
+    WaitForever,
     /// Keeps track of an `If` behavior.
-    IfState {
+    If {
         /// The behavior to run if the status is a success.
         on_success: Box<Behavior<A>>,
         /// The behavior to run if the status is a failure.
@@ -52,7 +52,7 @@ pub(crate) enum State<A> {
         current_state: Box<State<A>>,
     },
     /// Keeps track of a `Select` behavior.
-    SelectState {
+    Select {
         /// The behaviors that will be selected across in order.
         behaviors: Vec<Behavior<A>>,
         /// The index of the behavior currently being executed.
@@ -61,7 +61,7 @@ pub(crate) enum State<A> {
         current_state: Box<State<A>>,
     },
     /// Keeps track of an `Sequence` behavior.
-    SequenceState {
+    Sequence {
         /// The behaviors that will be executed in order.
         behaviors: Vec<Behavior<A>>,
         /// The index of the behavior currently being executed.
@@ -70,7 +70,7 @@ pub(crate) enum State<A> {
         current_state: Box<State<A>>,
     },
     /// Keeps track of a `While` behavior.
-    WhileState {
+    While {
         /// The state of the condition of the loop. The loop continues to run
         /// while this state is running.
         condition_state: Box<State<A>>,
@@ -82,7 +82,7 @@ pub(crate) enum State<A> {
         loop_body_state: Box<State<A>>,
     },
     /// Keeps track of a `WhileAll` behavior.
-    WhileAllState {
+    WhileAll {
         /// The state of the condition of the loop. The loop continues to run
         /// while this state is running, though this is only checked once at the
         /// start of each loop.
@@ -98,12 +98,12 @@ pub(crate) enum State<A> {
     },
     /// Keeps track of a `WhenAll` behavior. As the states finish, they are set
     /// to [`None`].
-    WhenAllState(Vec<Option<State<A>>>),
+    WhenAll(Vec<Option<State<A>>>),
     /// Keeps track of a `WhenAny` behavior. As the states finish, they are set
     /// to [`None`].
-    WhenAnyState(Vec<Option<State<A>>>),
+    WhenAny(Vec<Option<State<A>>>),
     /// Keeps track of an `After` behavior.
-    AfterState {
+    After {
         /// The index of the next state that must succeed.
         next_success_index: usize,
         /// The states for the behaviors currently executing. All the states
@@ -122,17 +122,17 @@ impl<A: Clone> State<A> {
     /// the executing instance of that behavior.
     pub fn new(behavior: Behavior<A>) -> Self {
         match behavior {
-            Behavior::Action(action) => State::ActionState(action),
-            Behavior::Invert(ev) => State::InvertState(Box::new(State::new(*ev))),
-            Behavior::AlwaysSucceed(ev) => State::AlwaysSucceedState(Box::new(State::new(*ev))),
-            Behavior::Wait(dt) => State::WaitState {
+            Behavior::Action(action) => State::Action(action),
+            Behavior::Invert(ev) => State::Invert(Box::new(State::new(*ev))),
+            Behavior::AlwaysSucceed(ev) => State::AlwaysSucceed(Box::new(State::new(*ev))),
+            Behavior::Wait(dt) => State::Wait {
                 time_to_wait: dt,
                 elapsed_time: 0.0,
             },
-            Behavior::WaitForever => State::WaitForeverState,
+            Behavior::WaitForever => State::WaitForever,
             Behavior::If(condition, on_success, on_failure) => {
                 let state = State::new(*condition);
-                State::IfState {
+                State::If {
                     on_success,
                     on_failure,
                     status: Status::Running,
@@ -141,7 +141,7 @@ impl<A: Clone> State<A> {
             }
             Behavior::Select(behaviors) => {
                 let state = State::new(behaviors[0].clone());
-                State::SelectState {
+                State::Select {
                     behaviors,
                     current_index: 0,
                     current_state: Box::new(state),
@@ -149,7 +149,7 @@ impl<A: Clone> State<A> {
             }
             Behavior::Sequence(behaviors) => {
                 let state = State::new(behaviors[0].clone());
-                State::SequenceState {
+                State::Sequence {
                     behaviors,
                     current_index: 0,
                     current_state: Box::new(state),
@@ -157,16 +157,16 @@ impl<A: Clone> State<A> {
             }
             Behavior::While(condition, loop_body) => {
                 let state = State::new(loop_body[0].clone());
-                State::WhileState {
+                State::While {
                     condition_state: Box::new(State::new(*condition)),
                     loop_body,
                     loop_body_index: 0,
                     loop_body_state: Box::new(state),
                 }
             }
-            Behavior::WhenAll(all) => State::WhenAllState(all.into_iter().map(|ev| Some(State::new(ev))).collect()),
-            Behavior::WhenAny(any) => State::WhenAnyState(any.into_iter().map(|ev| Some(State::new(ev))).collect()),
-            Behavior::After(after_all) => State::AfterState {
+            Behavior::WhenAll(all) => State::WhenAll(all.into_iter().map(|ev| Some(State::new(ev))).collect()),
+            Behavior::WhenAny(any) => State::WhenAny(any.into_iter().map(|ev| Some(State::new(ev))).collect()),
+            Behavior::After(after_all) => State::After {
                 next_success_index: 0,
                 states: after_all.into_iter().map(State::new).collect(),
             },
@@ -177,7 +177,7 @@ impl<A: Clone> State<A> {
                         .expect("WhileAll's sequence of behaviors to run cannot be empty!")
                         .clone(),
                 );
-                State::WhileAllState {
+                State::WhileAll {
                     condition_state: Box::new(State::new(*condition)),
                     check_condition: true,
                     loop_body,
@@ -209,7 +209,7 @@ impl<A: Clone> State<A> {
 
         // double match statements
         match (upd, self) {
-            (_, &mut ActionState(ref action)) => {
+            (_, &mut Action(ref action)) => {
                 // println!("In ActionState: {:?}", action);
                 f(
                     ActionArgs {
@@ -220,7 +220,7 @@ impl<A: Clone> State<A> {
                     blackboard,
                 )
             }
-            (_, &mut InvertState(ref mut cur)) => {
+            (_, &mut Invert(ref mut cur)) => {
                 // println!("In InvertState: {:?}", cur);
                 match cur.tick(e, blackboard, f) {
                     (Running, dt) => (Running, dt),
@@ -228,7 +228,7 @@ impl<A: Clone> State<A> {
                     (Success, dt) => (Failure, dt),
                 }
             }
-            (_, &mut AlwaysSucceedState(ref mut cur)) => {
+            (_, &mut AlwaysSucceed(ref mut cur)) => {
                 // println!("In AlwaysSucceedState: {:?}", cur);
                 match cur.tick(e, blackboard, f) {
                     (Running, dt) => (Running, dt),
@@ -237,7 +237,7 @@ impl<A: Clone> State<A> {
             }
             (
                 Some(dt),
-                &mut WaitState {
+                &mut Wait {
                     time_to_wait,
                     ref mut elapsed_time,
                 },
@@ -254,7 +254,7 @@ impl<A: Clone> State<A> {
             }
             (
                 _,
-                &mut IfState {
+                &mut If {
                     ref on_success,
                     ref on_failure,
                     ref mut status,
@@ -301,7 +301,7 @@ impl<A: Clone> State<A> {
             }
             (
                 _,
-                &mut SelectState {
+                &mut Select {
                     behaviors: ref seq,
                     current_index: ref mut i,
                     current_state: ref mut cursor,
@@ -322,7 +322,7 @@ impl<A: Clone> State<A> {
             }
             (
                 _,
-                &mut SequenceState {
+                &mut Sequence {
                     behaviors: ref seq,
                     current_index: ref mut i,
                     current_state: ref mut cursor,
@@ -343,7 +343,7 @@ impl<A: Clone> State<A> {
             }
             (
                 _,
-                &mut WhileState {
+                &mut While {
                     ref mut condition_state,
                     ref loop_body,
                     ref mut loop_body_index,
@@ -394,19 +394,19 @@ impl<A: Clone> State<A> {
                 }
                 RUNNING
             }
-            (_, &mut WhenAllState(ref mut cursors)) => {
+            (_, &mut WhenAll(ref mut cursors)) => {
                 // println!("In WhenAllState: {:?}", cursors);
                 let any = false;
                 when_all(any, upd, cursors, e, f, blackboard)
             }
-            (_, &mut WhenAnyState(ref mut cursors)) => {
+            (_, &mut WhenAny(ref mut cursors)) => {
                 // println!("In WhenAnyState: {:?}", cursors);
                 let any = true;
                 when_all(any, upd, cursors, e, f, blackboard)
             }
             (
                 _,
-                &mut AfterState {
+                &mut After {
                     ref mut next_success_index,
                     ref mut states,
                 },
@@ -443,7 +443,7 @@ impl<A: Clone> State<A> {
             }
             (
                 _,
-                &mut WhileAllState {
+                &mut WhileAll {
                     ref mut condition_state,
                     ref mut check_condition,
                     ref loop_body,

--- a/bonsai/src/visualizer.rs
+++ b/bonsai/src/visualizer.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, unused_imports, unused_variables)]
-use crate::{Behavior, Select, Sequence, State, BT};
+use crate::{state::State, Behavior, Select, Sequence, BT};
 use petgraph::{graph::Graph, stable_graph::NodeIndex, Direction::Outgoing};
 use std::{collections::VecDeque, fmt::Debug};
 

--- a/bonsai/src/when_all.rs
+++ b/bonsai/src/when_all.rs
@@ -1,5 +1,5 @@
 use crate::status::Status::*;
-use crate::{event::UpdateEvent, ActionArgs, State, Status, RUNNING};
+use crate::{event::UpdateEvent, state::State, ActionArgs, Status, RUNNING};
 
 // `WhenAll` and `WhenAny` share same algorithm.
 //

--- a/bonsai/tests/dynamic_behavior_tests.rs
+++ b/bonsai/tests/dynamic_behavior_tests.rs
@@ -1,5 +1,5 @@
 use crate::dynamic_behavior_tests::TestActions::{DynamicWait, Inc};
-use bonsai_bt::{Action, ActionArgs, Event, State, Success, UpdateArgs, Wait, While, RUNNING};
+use bonsai_bt::{Action, ActionArgs, Event, Success, UpdateArgs, Wait, While, BT, RUNNING};
 
 type Times = Vec<f64>;
 /// Some test actions.
@@ -12,37 +12,33 @@ enum TestActions {
 }
 
 // A test state machine that can increment and decrement.
-fn tick(mut acc: usize, dt: f64, t: &mut f64, counter: &mut usize, state: &mut State<TestActions>) -> usize {
+fn tick(mut acc: usize, dt: f64, t: &mut f64, counter: &mut usize, state: &mut BT<TestActions, ()>) -> usize {
     let e: Event = UpdateArgs { dt }.into();
 
-    let (_s, _t) = state.tick(
-        &e,
-        &mut (),
-        &mut |args: ActionArgs<Event, TestActions>, _| match args.action {
-            Inc => {
-                acc += 1;
-                (Success, args.dt)
+    let (_s, _t) = state.tick(&e, &mut |args: ActionArgs<Event, TestActions>, _| match args.action {
+        Inc => {
+            acc += 1;
+            (Success, args.dt)
+        }
+        DynamicWait(times) => {
+            // reset dynamic timer
+            if *counter >= times.len() {
+                *counter = 0
             }
-            DynamicWait(times) => {
-                // reset dynamic timer
-                if *counter >= times.len() {
-                    *counter = 0
-                }
 
-                let wait_t = times[counter.to_owned()];
+            let wait_t = times[counter.to_owned()];
 
-                if *t + dt >= wait_t {
-                    let time_overdue = *t + dt - wait_t;
-                    *counter += 1;
-                    *t = -dt;
-                    (Success, time_overdue)
-                } else {
-                    *t += dt;
-                    RUNNING
-                }
+            if *t + dt >= wait_t {
+                let time_overdue = *t + dt - wait_t;
+                *counter += 1;
+                *t = -dt;
+                (Success, time_overdue)
+            } else {
+                *t += dt;
+                RUNNING
             }
-        },
-    );
+        }
+    });
 
     acc
 }
@@ -56,7 +52,7 @@ fn test_alter_wait_time() {
         Box::new(Wait(50.0)),
         vec![Action(DynamicWait(vec![1.0, 2.0, 3.0])), Action(Inc)],
     );
-    let mut state = State::new(rep);
+    let mut state = BT::new(rep, ());
 
     // time passed=1.0
     let a = tick(a, 1.0, &mut timer, &mut counter, &mut state);


### PR DESCRIPTION
Today, ticking a behavior tree after it has finished has confusing results. Looking at the code, it seems the intent was that once a `State` finishes, it is not expected to tick again. For example, if you tick a Sequence/Select after it has finished, it always returns `Running`. Here's an example test that shows this strange behavior:

```rust
#[test]
fn weird_behavior() {
    let a = 4;

    let mut bt = BT::new(
        Select(vec![
            Invert(Box::new(Action(Dec))),
            Invert(Box::new(Action(Dec))),
            Invert(Box::new(Action(Dec))),
        ]),
        (),
    );

    let (a, s, _) = tick(a, 0.1, &mut bt);
    assert_eq!(a, 1);
    assert_eq!(s, Failure);
    let (a, s, _) = tick(a, 0.1, &mut bt);
    assert_eq!(a, 1);
    assert_eq!(s, Running);
    let (a, s, _) = tick(a, 0.1, &mut bt);
    assert_eq!(a, 1);
    assert_eq!(s, Running);
}
```

This is clearly wrong. We could fix this particular issue (make Sequence/Select return a finished status if you tick it again), but it's not clear that ticking a finished behavior makes sense at all - so perhaps we should stop that.

There are two options then:
1) Prevent the BT from being used after it's finished. We could make the `State` an `Option` and `take` it once the `State` finishes. This requires us to return an error to the user, and the user to for example, reset the tree.
2) Make the tree just reset to its initial state.

This PR does the latter. It is likely what users would expect (you can keep ticking your tree), and the behavior is well defined.