### PR TITLE
Return `None` if ticking `BT` after it finishes.

### DIFF
--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 petgraph = "0.6.2"
+thiserror = "2"
 serde = { version = "1.0.137", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -20,7 +20,6 @@ path = "src/lib.rs"
 
 [dependencies]
 petgraph = "0.6.2"
-thiserror = "2"
 serde = { version = "1.0.137", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -93,6 +93,12 @@ impl<A: Clone, B> BT<A, B> {
         self.state = State::new(initial_behavior);
         self.finished = false;
     }
+
+    /// Whether this behavior tree is in a completed state (the last tick returned
+    /// [`Status::Success`] or [`Status::Failure`]).
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
 }
 
 impl<A: Clone + Debug, B: Debug> BT<A, B> {

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -60,7 +60,7 @@
 //!             acc -= 1;
 //!             (Success, args.dt)
 //!         }
-//!     });
+//!     }).unwrap();
 //!
 //!     // update counter in blackboard
 //!     let bb = bt.get_blackboard();

--- a/bonsai/src/visualizer.rs
+++ b/bonsai/src/visualizer.rs
@@ -154,16 +154,18 @@ mod tests {
     // A test state machine that can increment and decrement.
     fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> (i32, Status, f64) {
         let e: Event = UpdateArgs { dt }.into();
-        let (s, t) = bt.tick(&e, &mut |args, blackboard| match args.action {
-            TestActions::Inc => {
-                acc += 1;
-                (Success, args.dt)
-            }
-            TestActions::Dec => {
-                acc -= 1;
-                (Success, args.dt)
-            }
-        });
+        let (s, t) = bt
+            .tick(&e, &mut |args, blackboard| match args.action {
+                TestActions::Inc => {
+                    acc += 1;
+                    (Success, args.dt)
+                }
+                TestActions::Dec => {
+                    acc -= 1;
+                    (Success, args.dt)
+                }
+            })
+            .unwrap();
         (acc, s, t)
     }
 

--- a/bonsai/tests/blackboard_tests.rs
+++ b/bonsai/tests/blackboard_tests.rs
@@ -17,16 +17,18 @@ pub enum TestActions {
 fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> i32 {
     let e: Event = UpdateArgs { dt }.into();
 
-    let (_s, _t) = bt.tick(&e, &mut |args, _| match *args.action {
-        Inc => {
-            acc += 1;
-            (Success, args.dt)
-        }
-        Dec => {
-            acc -= 1;
-            (Success, args.dt)
-        }
-    });
+    let (_s, _t) = bt
+        .tick(&e, &mut |args, _| match *args.action {
+            Inc => {
+                acc += 1;
+                (Success, args.dt)
+            }
+            Dec => {
+                acc -= 1;
+                (Success, args.dt)
+            }
+        })
+        .unwrap();
 
     // update counter in blackboard
     let bb = bt.get_blackboard();

--- a/bonsai/tests/bt_tests.rs
+++ b/bonsai/tests/bt_tests.rs
@@ -18,26 +18,28 @@ enum TestActions {
 fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -> (i32, bonsai_bt::Status, f64) {
     let e: Event = UpdateArgs { dt }.into();
     println!("acc {}", acc);
-    let (s, t) = bt.tick(&e, &mut |args, _| match *args.action {
-        Inc => {
-            acc += 1;
-            (Success, args.dt)
-        }
-        Dec => {
-            acc -= 1;
-            (Success, args.dt)
-        }
-        LessThan(v) => {
-            println!("inside less than with acc: {}", acc);
-            if acc < v {
-                println!("success {}<{}", acc, v);
+    let (s, t) = bt
+        .tick(&e, &mut |args, _| match *args.action {
+            Inc => {
+                acc += 1;
                 (Success, args.dt)
-            } else {
-                println!("failure {}>={}", acc, v);
-                (Failure, args.dt)
             }
-        }
-    });
+            Dec => {
+                acc -= 1;
+                (Success, args.dt)
+            }
+            LessThan(v) => {
+                println!("inside less than with acc: {}", acc);
+                if acc < v {
+                    println!("success {}<{}", acc, v);
+                    (Success, args.dt)
+                } else {
+                    println!("failure {}>={}", acc, v);
+                    (Failure, args.dt)
+                }
+            }
+        })
+        .unwrap();
     println!("status: {:?} dt: {}", s, t);
 
     (acc, s, t)
@@ -54,14 +56,14 @@ fn test_select_succeed_on_second_last() {
     let (a, s, _) = tick(a, 0.1, &mut bt);
     assert_eq!(a, 2);
     assert_eq!(s, Success);
+    bt.reset_bt();
     let (a, s, _) = tick(a, 0.1, &mut bt);
     assert_eq!(a, 1);
     assert_eq!(s, Success);
+    bt.reset_bt();
     let (a, s, _) = tick(a, 0.1, &mut bt);
     assert_eq!(a, 0);
     assert_eq!(s, Success);
-
-    // reset bt
     bt.reset_bt();
     let (a, s, _) = tick(a, 0.1, &mut bt);
     assert_eq!(a, 0);

--- a/bonsai/tests/dynamic_behavior_tests.rs
+++ b/bonsai/tests/dynamic_behavior_tests.rs
@@ -15,30 +15,32 @@ enum TestActions {
 fn tick(mut acc: usize, dt: f64, t: &mut f64, counter: &mut usize, state: &mut BT<TestActions, ()>) -> usize {
     let e: Event = UpdateArgs { dt }.into();
 
-    let (_s, _t) = state.tick(&e, &mut |args: ActionArgs<Event, TestActions>, _| match args.action {
-        Inc => {
-            acc += 1;
-            (Success, args.dt)
-        }
-        DynamicWait(times) => {
-            // reset dynamic timer
-            if *counter >= times.len() {
-                *counter = 0
+    let (_s, _t) = state
+        .tick(&e, &mut |args: ActionArgs<Event, TestActions>, _| match args.action {
+            Inc => {
+                acc += 1;
+                (Success, args.dt)
             }
+            DynamicWait(times) => {
+                // reset dynamic timer
+                if *counter >= times.len() {
+                    *counter = 0
+                }
 
-            let wait_t = times[counter.to_owned()];
+                let wait_t = times[counter.to_owned()];
 
-            if *t + dt >= wait_t {
-                let time_overdue = *t + dt - wait_t;
-                *counter += 1;
-                *t = -dt;
-                (Success, time_overdue)
-            } else {
-                *t += dt;
-                RUNNING
+                if *t + dt >= wait_t {
+                    let time_overdue = *t + dt - wait_t;
+                    *counter += 1;
+                    *t = -dt;
+                    (Success, time_overdue)
+                } else {
+                    *t += dt;
+                    RUNNING
+                }
             }
-        }
-    });
+        })
+        .unwrap();
 
     acc
 }

--- a/examples/src/3d/main.rs
+++ b/examples/src/3d/main.rs
@@ -194,7 +194,7 @@ fn game_tick(
             },
 
         },
-    );
+    ).unwrap();
 
     // update blackboard
     let db = bt.get_blackboard();

--- a/examples/src/async_drone/main.rs
+++ b/examples/src/async_drone/main.rs
@@ -180,7 +180,7 @@ async fn drone_tick(
                 }
             },
         }
-    );
+    ).unwrap();
 }
 
 #[tokio::main]

--- a/examples/src/boids/boid.rs
+++ b/examples/src/boids/boid.rs
@@ -172,5 +172,5 @@ pub fn game_tick(dt: f32, cursor: mint::Point2<f32>, boid: &mut Boid, other_boid
             },
         }
 
-    });
+    }).unwrap();
 }

--- a/examples/src/simple_npc_ai/main.rs
+++ b/examples/src/simple_npc_ai/main.rs
@@ -58,7 +58,7 @@ fn game_tick(bt: &mut BT<EnemyNPC, BlackBoardData>, state: &mut EnemyNPCState) -
                 (Success, 0.0)
             }
         }
-    });
+    }).unwrap();
 
     // return status:
     status.0


### PR DESCRIPTION
Today, ticking a behavior tree after it has finished has confusing results. Looking at the code, it seems the intent was that once a `State` finishes, it is not expected to tick again. For example, if you tick a Sequence/Select after it has finished, it always returns `Running`. Here's an example test that shows this strange behavior:

```rust
#[test]
fn weird_behavior() {
    let a = 4;

    let mut bt = BT::new(
        Select(vec![
            Invert(Box::new(Action(Dec))),
            Invert(Box::new(Action(Dec))),
            Invert(Box::new(Action(Dec))),
        ]),
        (),
    );

    let (a, s, _) = tick(a, 0.1, &mut bt);
    assert_eq!(a, 1);
    assert_eq!(s, Failure);
    let (a, s, _) = tick(a, 0.1, &mut bt);
    assert_eq!(a, 1);
    assert_eq!(s, Running);
    let (a, s, _) = tick(a, 0.1, &mut bt);
    assert_eq!(a, 1);
    assert_eq!(s, Running);
}
```

This is clearly wrong. We could fix this particular issue (make Sequence/Select return a finished status if you tick it again), but it's not clear that ticking a finished behavior makes sense at all - so perhaps we should stop that.

This PR solves this by just keeping track of the BT returns a Success or Failure status and then prevents ticking in those cases (returning an Option)