### PR TITLE
Hide all the visualization code behind a `visualize` feature flag.

### DIFF
--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -19,8 +19,11 @@ name = "bonsai_bt"
 path = "src/lib.rs"
 
 [dependencies]
-petgraph = "0.6.2"
+petgraph = { version = "0.6.2", optional = true }
 serde = { version = "1.0.137", features = ["derive"], optional = true }
+
+[features]
+visualize = ["dep:petgraph"]
 
 [dev-dependencies]
 serde_json = { version = "1.0.81" }

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -1,9 +1,6 @@
 use std::fmt::Debug;
 
-use crate::visualizer::NodeType;
 use crate::{state::State, ActionArgs, Behavior, Status, UpdateEvent};
-use petgraph::dot::{Config, Dot};
-use petgraph::Graph;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -79,6 +76,7 @@ impl<A: Clone, B> BT<A, B> {
     }
 }
 
+#[cfg(feature = "visualize")]
 impl<A: Clone + Debug, B: Debug> BT<A, B> {
     /// Compile the behavior tree into a [graphviz](https://graphviz.org/) compatible [DiGraph](https://docs.rs/petgraph/latest/petgraph/graph/type.DiGraph.html).
     ///
@@ -113,7 +111,13 @@ impl<A: Clone + Debug, B: Debug> BT<A, B> {
         self.get_graphviz_with_graph_instance().0
     }
 
-    pub(crate) fn get_graphviz_with_graph_instance(&mut self) -> (String, Graph<NodeType<A>, u32>) {
+    pub(crate) fn get_graphviz_with_graph_instance(
+        &mut self,
+    ) -> (String, petgraph::Graph<crate::visualizer::NodeType<A>, u32>) {
+        use crate::visualizer::NodeType;
+        use petgraph::dot::{Config, Dot};
+        use petgraph::Graph;
+
         let behavior = self.initial_behavior.to_owned();
 
         let mut graph = Graph::<NodeType<A>, u32, petgraph::Directed>::new();

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -133,5 +133,7 @@ mod event;
 mod sequence;
 mod state;
 mod status;
-mod visualizer;
 mod when_all;
+
+#[cfg(feature = "visualize")]
+mod visualizer;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 version = "0.1.0"
 
 [dependencies]
-bonsai-bt = { path = "../bonsai" , features = ["serde"]}
+bonsai-bt = { path = "../bonsai", features = ["serde", "visualize"] }
 futures = "0.3.24"
 tokio = { version = "1.21.1", features = [
     "rt-multi-thread",


### PR DESCRIPTION
This also makes petgraph an optional dependency.

Note we're already at version 0.9.0 (unreleased) so there's no need to bump the version again.