### PR TITLE
Implement blackboard immutable reference function

### DIFF
--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -12,7 +12,7 @@ name = "bonsai-bt"
 readme = "../README.md"
 repository = "https://github.com/sollimann/bonsai.git"
 rust-version = "1.80.0"
-version = "0.9.0"
+version = "0.10.0"
 
 [lib]
 name = "bonsai_bt"

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -67,9 +67,15 @@ impl<A: Clone, B> BT<A, B> {
         }
     }
 
+    /// Retrieve a immutable reference to the blackboard for
+    /// this Behavior Tree
+    pub fn blackboard(&self) -> &B {
+        &self.bb
+    }
+
     /// Retrieve a mutable reference to the blackboard for
     /// this Behavior Tree
-    pub fn get_blackboard(&mut self) -> &mut B {
+    pub fn blackboard_mut(&mut self) -> &mut B {
         &mut self.bb
     }
 

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -67,7 +67,7 @@ impl<A: Clone, B> BT<A, B> {
         }
     }
 
-    /// Retrieve a immutable reference to the blackboard for
+    /// Retrieve an immutable reference to the blackboard for
     /// this Behavior Tree
     pub fn blackboard(&self) -> &B {
         &self.bb

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -63,7 +63,7 @@
 //!     }).unwrap();
 //!
 //!     // update counter in blackboard
-//!     let bb = bt.get_blackboard();
+//!     let bb = bt.blackboard_mut();
 //!
 //!     bb.entry("count".to_string())
 //!         .and_modify(|count| *count = acc)
@@ -107,7 +107,7 @@
 //!     let a = tick(a, 0.5, &mut bt);
 //!     assert_eq!(a, 1);
 //!
-//!     let bb = bt.get_blackboard();
+//!     let bb = bt.blackboard_mut();
 //!     let count = bb.get("count").unwrap();
 //!     assert_eq!(*count, 1);
 //!

--- a/bonsai/tests/blackboard_tests.rs
+++ b/bonsai/tests/blackboard_tests.rs
@@ -31,7 +31,7 @@ fn tick(mut acc: i32, dt: f64, bt: &mut BT<TestActions, HashMap<String, i32>>) -
         .unwrap();
 
     // update counter in blackboard
-    let bb = bt.get_blackboard();
+    let bb = bt.blackboard_mut();
 
     bb.entry("count".to_string())
         .and_modify(|count| *count = acc)
@@ -64,7 +64,7 @@ fn test_crate_bt() {
     let a = tick(a, 0.5, &mut bt);
     assert_eq!(a, 1);
 
-    let bb = bt.get_blackboard();
+    let bb = bt.blackboard_mut();
     let count = bb.get("count").unwrap();
     assert_eq!(*count, 1);
 }

--- a/examples/src/3d/main.rs
+++ b/examples/src/3d/main.rs
@@ -90,7 +90,7 @@ fn game_tick(
     let e: Event = UpdateArgs { dt }.into();
 
     // get data from blackboard
-    let db = bt.get_blackboard();
+    let db = bt.blackboard_mut();
     let inc: u64 = db.get("count").map_or(Some(0), |x| x.as_u64()).unwrap();
 
     let mut last_pos = mouse_pos(0.0, 0.0);
@@ -197,7 +197,7 @@ fn game_tick(
     ).unwrap();
 
     // update blackboard
-    let db = bt.get_blackboard();
+    let db = bt.blackboard_mut();
 
     // update count
     let _count = db

--- a/examples/src/boids/boid.rs
+++ b/examples/src/boids/boid.rs
@@ -60,7 +60,7 @@ pub fn game_tick(dt: f32, cursor: mint::Point2<f32>, boid: &mut Boid, other_boid
 
     // unwrap bt for boid
     let mut bt = boid.bt.clone();
-    let db = bt.get_blackboard();
+    let db = bt.blackboard_mut();
     let win_width: f32 = *db.get("win_width").unwrap();
     let win_height: f32 = *db.get("win_height").unwrap();
 

--- a/examples/src/simple_npc_ai/main.rs
+++ b/examples/src/simple_npc_ai/main.rs
@@ -174,7 +174,7 @@ fn main() {
     }
     println!(
         "NPC shot {} times during the simulation.",
-        bt.get_blackboard().times_shot
+        bt.blackboard_mut().times_shot
     );
 }
 


### PR DESCRIPTION
First of all, thank you for creating such a great framework.

In the code I’m currently working on, I was using an older version of bonsai-bt. However, as the version was updated, an issue arose.

The interface was modified to integrate the blackboard into the bt, which caused problems with the existing logic that relied on an immutable borrow of the blackboard. To address this, I added an immutable reference function. Could you take a look and let me know if it looks okay?