### PR TITLE
Specify resolver version as requested by the compiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["bonsai", "examples"]


### PR DESCRIPTION
Adds resolver = "2", as requested by the compiler when you compile the crate.