### PR TITLE
Automate python publishing on version bumps

### DIFF
--- a/.github/workflows/auto-tag-py.yml
+++ b/.github/workflows/auto-tag-py.yml
@@ -1,0 +1,55 @@
+name: Auto-tag Python release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'bonsai-py/Cargo.toml'
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TAG_PAT }}
+          fetch-depth: 0  # need full history so `git rev-parse` can see existing tags
+
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          version=$(grep -m1 '^version' bonsai-py/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ -z "$version" ]; then
+            echo "::error::Could not parse version from bonsai-py/Cargo.toml"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $version"
+
+      - name: Check if py-v tag already exists
+        id: check
+        run: |
+          v="${{ steps.version.outputs.version }}"
+          if git rev-parse "py-v$v" >/dev/null 2>&1; then
+            echo "py-v$v already exists — no-op."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "py-v$v does not exist — will tag."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Push py-v-X.Y.Z (real PyPI release)
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          v="${{ steps.version.outputs.version }}"
+          git tag "py-v$v"
+          git push origin "py-v$v"

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -3,7 +3,7 @@ name: Python wheels
 on:
   push:
     branches: [main]
-    tags: ["py-v*", "py-test-*"]
+    tags: ["py-v*"]
   pull_request:
     branches: [main]
   workflow_dispatch:  # manual ad-hoc builds from any branch
@@ -63,7 +63,6 @@ jobs:
         run: |
           tag="${GITHUB_REF#refs/tags/}"
           version="${tag#py-v}"
-          version="${version#py-test-}"
           cargo_version=$(grep -m1 '^version' bonsai-py/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
           if [ "$version" != "$cargo_version" ]; then
             echo "::error::Tag version '$version' does not match Cargo.toml version '$cargo_version'."
@@ -149,12 +148,12 @@ jobs:
           python -c "import bonsai_bt; print(bonsai_bt.__version__)"
 
   publish:
-    name: Publish to PyPI / TestPyPI
+    name: Publish to PyPI
     needs: [build, sdist, verify-sdist]
-    if: startsWith(github.ref, 'refs/tags/py-v') || startsWith(github.ref, 'refs/tags/py-test-')
+    if: startsWith(github.ref, 'refs/tags/py-v')
     runs-on: ubuntu-latest
     environment:
-      name: ${{ startsWith(github.ref, 'refs/tags/py-test-') && 'testpypi' || 'pypi' }}
+      name: pypi
     permissions:
       id-token: write   # OIDC for Trusted Publishing
     steps:
@@ -174,7 +173,5 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: >-
-            ${{ startsWith(github.ref, 'refs/tags/py-test-') && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist
           skip-existing: true

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 <!-- [![version](https://img.shields.io/badge/version-1.0.0-blue)](https://GitHub.com/Sollimann/CleanIt/releases/) -->
 [![Build Status](https://github.com/Sollimann/bonsai/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/Sollimann/bonsai/actions)
 [![Bonsai crate](https://img.shields.io/crates/v/bonsai-bt.svg)](https://crates.io/crates/bonsai-bt)
+[![PyPI](https://img.shields.io/pypi/v/bonsai-bt.svg?label=pypi%20%28bonsai-bt%29)](https://pypi.org/project/bonsai-bt/)
 [![minimum rustc 1.72](https://img.shields.io/badge/rustc-1.72+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![Docs](https://docs.rs/bonsai-bt/badge.svg)](https://docs.rs/bonsai-bt)
 [![codecov](https://codecov.io/gh/Sollimann/bonsai/branch/main/graph/badge.svg?token=JX8JBPWORV)](https://codecov.io/gh/Sollimann/bonsai)
@@ -41,7 +42,13 @@ bonsai-bt = "*"
 
 ### Python
 
-Python bindings are available — see [`bonsai-py/`](bonsai-py/) for installation, examples, and a side-by-side comparison of the same BT in Rust and Python. The package wraps the same Rust crate, so the BT semantics are identical; only the API surface differs.
+Bonsai is available on PyPI as [**`bonsai-bt`**](https://pypi.org/project/bonsai-bt/):
+
+```bash
+pip install bonsai-bt
+```
+
+See [`bonsai-py/`](bonsai-py/) for examples.
 
 ## What is a Behavior Tree?
 

--- a/bonsai-py/Cargo.toml
+++ b/bonsai-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonsai-py"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 rust-version = "1.80.0"
 description = "Python bindings for the bonsai-bt behavior tree library"

--- a/bonsai-py/README.md
+++ b/bonsai-py/README.md
@@ -1,9 +1,30 @@
-# bonsai-bt - Python bindings
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/Sollimann/bonsai/main/docs/resources/gifs/bonsai.gif" width="350" alt="Bonsai logo">
+</p>
+
+[![PyPI](https://img.shields.io/pypi/v/bonsai-bt.svg)](https://pypi.org/project/bonsai-bt/)
+[![Python](https://img.shields.io/pypi/pyversions/bonsai-bt.svg)](https://pypi.org/project/bonsai-bt/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Python bindings for the [bonsai-bt](https://github.com/sollimann/bonsai)
 behavior-tree library.
 
+## Install
+
+```bash
+pip install bonsai-bt
+```
+
+The package is published on PyPI as [**`bonsai-bt`**](https://pypi.org/project/bonsai-bt/) and imported as `bonsai_bt`:
+
+```python
+import bonsai_bt as bt
+```
+
 ## Installation (dev)
+
+For building from source — needed if you're contributing to the Rust core or developing against an unpublished version:
 
 ```bash
 python -m venv .venv

--- a/bonsai-py/tests/test_module.py
+++ b/bonsai-py/tests/test_module.py
@@ -5,8 +5,8 @@ import bonsai_bt as bt
 
 
 def test_version_present() -> None:
-    """bt.__version__ pins the wheel version (0.12.0); bump per release."""
-    assert bt.__version__ == "0.12.0"
+    """bt.__version__ pins the wheel version (0.12.1); bump per release."""
+    assert bt.__version__ == "0.12.1"
 
 
 def test_docstring_present() -> None:


### PR DESCRIPTION
Automate the Python release pipeline so a `bonsai-py/Cargo.toml` version bump on main
auto-tags + triggers publish.

- Watches `bonsai-py/Cargo.toml`, pushes py-v$version
  on change. Uses a PAT (RELEASE_TAG_PAT) because GITHUB_TOKEN-pushed
  tags don't fire downstream workflows.