### PR TITLE
docs: cleanups and small improvements

### DIFF
--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -12,7 +12,7 @@ name = "bonsai-bt"
 readme = "../README.md"
 repository = "https://github.com/sollimann/bonsai.git"
 rust-version = "1.80.0"
-version = "0.13.0"
+version = "0.13.1"
 
 [lib]
 name = "bonsai_bt"

--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -32,5 +32,8 @@ f32 = []
 serde_json = { version = "1.0.81" }
 tungstenite = { version = "0.21" }
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [[test]]
 name = "tests"

--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -166,7 +166,7 @@ impl<A: Clone, B> BT<A, B> {
     /// that the behavior has concluded and ticking the BT won't progress any further - then it could
     /// be desirable to return the BT to it's initial state at t=0.0 before it was ever ticked.
     ///
-    /// PS! invoking reset_bt does not reset the Blackboard.
+    /// <div class="warning">Invoking <code>reset_bt()</code> does not reset the Blackboard.</div>
     pub fn reset_bt(&mut self) {
         let initial_behavior = self.initial_behavior.to_owned();
         self.state = State::new(initial_behavior);

--- a/bonsai/src/bt_telemetry.rs
+++ b/bonsai/src/bt_telemetry.rs
@@ -16,7 +16,7 @@ impl<A: Clone, B> BT<A, B> {
     }
 
     /// Tick the tree once and return both the standard tick result and a
-    /// [`TickTrace`](crate::telemetry::TickTrace) recording every node visited
+    /// [`TickTrace`] recording every node visited
     /// this frame. Used by the in-process telemetry channel and by integration
     /// tests.
     ///
@@ -72,7 +72,7 @@ impl<A: Clone, B> BT<A, B> {
     ///
     /// Builder method: consumes and returns `Self` for chaining off [`BT::new`].
     /// Spawns a listener thread and a broadcaster thread. Telemetry is
-    /// **best-effort** — [`TickTrace`](crate::telemetry::TickTrace)s are dropped
+    /// **best-effort** — [`TickTrace`]s are dropped
     /// silently when the channel is full; the count is surfaced via
     /// [`dropped_traces`](Self::dropped_traces).
     ///
@@ -107,7 +107,7 @@ impl<A: Clone, B> BT<A, B> {
     /// so hostnames and IPv6 literals (e.g. `"::1"`) also work.
     ///
     /// Spawns a listener thread and a broadcaster thread. Telemetry is
-    /// **best-effort** — [`TickTrace`](crate::telemetry::TickTrace)s are dropped
+    /// **best-effort** — [`TickTrace`]s are dropped
     /// silently when the channel is full; the count is surfaced via
     /// [`dropped_traces`](Self::dropped_traces).
     ///

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -157,8 +157,16 @@ mod visualizer_server;
 #[doc(hidden)]
 pub use visualizer_server::spawn_server;
 
+/// Float type used in [`BT::tick()`] and everywhere in the crate.
+///
+/// - If feature `f32` is active => [`f32`]
+/// - Else => [`f64`]
 #[cfg(feature = "f32")]
 pub type Float = f32;
 
+/// Float type used in [`BT::tick()`] and everywhere in the crate.
+///
+/// - If feature `f32` is active => [`f32`]
+/// - Else => [`f64`]
 #[cfg(not(feature = "f32"))]
 pub type Float = f64;

--- a/bonsai/src/telemetry.rs
+++ b/bonsai/src/telemetry.rs
@@ -6,10 +6,10 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-/// `NodeMeta` lives in the always-on [`crate::tracer`] module because
-/// `State::tick`'s signature depends on it regardless of the `visualize`
-/// feature. Re-exported here so the public path `bonsai_bt::telemetry::NodeMeta`
-/// stays valid for downstream code.
+// `NodeMeta` lives in the always-on `crate::tracer` module because
+// `State::tick`'s signature depends on it regardless of the `visualize`
+// feature. Re-exported here so the public path `bonsai_bt::telemetry::NodeMeta`
+// stays valid for downstream code.
 pub use crate::tracer::NodeMeta;
 
 use crate::tracer::Tracer;

--- a/bonsai/src/telemetry.rs
+++ b/bonsai/src/telemetry.rs
@@ -1,6 +1,6 @@
-//! Visualize-only telemetry types. The whole module is gated on the
-//! `visualize` feature in [`lib.rs`](crate); per-item `#[cfg]` gates are
-//! therefore unnecessary inside this file.
+//! Visualize-only telemetry types.
+// The whole module is gated on the `visualize` feature in [`lib.rs`](crate);
+// per-item `#[cfg]` gates are therefore unnecessary inside this file.
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
Each commit can be reviewed on its own and is hopefully self-contained enough to be clear.

- docs: add `package.metadata.docs.rs` entry
- docs: Documentation for `Float` type alias
- docs: remove redundant intra-doc links
- docs: don't expose internal organization comment in public docs
- docs: don't use a doc comment on NodeMeta's reexport
- docs: Use Rustdoc's builtin warning div for `BT::reset_bt()`

Command to see the rendered docs: `RUSTDOCFLAGS="-Z unstable-options --generate-link-to-definition" cargo +nightly doc --workspace --no-deps`