### PR TITLE
feat(bt): add BT::into_inner to retrieve owned blackboard

### DIFF
--- a/bonsai/src/bt.rs
+++ b/bonsai/src/bt.rs
@@ -156,6 +156,15 @@ impl<A: Clone, B> BT<A, B> {
         &mut self.bb
     }
 
+    /// Consume the Behavior Tree and retrieve the owned blackboard object.
+    ///
+    /// Useful once the tree has finished running and you want to take back the
+    /// blackboard without paying for a `clone()`. Mirrors the `blackboard()` /
+    /// `blackboard_mut()` accessors, but transfers ownership instead of borrowing.
+    pub fn into_inner(self) -> B {
+        self.bb
+    }
+
     /// The behavior tree is a stateful data structure in which the immediate
     /// state of the BT is allocated and updated in heap memory through the lifetime
     /// of the BT. The state of the BT is said to be `transient` meaning upon entering

--- a/bonsai/tests/blackboard_tests.rs
+++ b/bonsai/tests/blackboard_tests.rs
@@ -68,3 +68,18 @@ fn test_crate_bt() {
     let count = bb.get("count").unwrap();
     assert_eq!(*count, 1);
 }
+
+#[test]
+fn test_into_inner_returns_owned_blackboard() {
+    let seq = Sequence(vec![Action(Inc)]);
+    let mut h: HashMap<String, i32> = HashMap::new();
+    h.insert("count".to_string(), 0);
+    let mut bt = BT::new(seq, h);
+
+    // Mutate through the reference accessor...
+    bt.blackboard_mut().insert("count".to_string(), 7);
+
+    // ...then take ownership of the blackboard without cloning.
+    let owned = bt.into_inner();
+    assert_eq!(owned.get("count"), Some(&7));
+}


### PR DESCRIPTION
Addresses #50.

Adds `BT::into_inner(self) -> B`, which consumes the behavior tree and returns the owned blackboard, avoiding an unnecessary `clone()` once the tree has finished running.

- Mirrors the existing `blackboard()` / `blackboard_mut()` accessors, but transfers ownership.
- Includes a unit test (`test_into_inner_returns_owned_blackboard`).

Tests: `cargo test -p bonsai-bt` → 52 passed; clippy and `cargo fmt --check` clean.