### PR TITLE
ci: automate crates.io publishing for bonsai-bt on version bump

### DIFF
--- a/.github/workflows/auto-tag-rust.yml
+++ b/.github/workflows/auto-tag-rust.yml
@@ -1,0 +1,55 @@
+name: Auto-tag Rust release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'bonsai/Cargo.toml'
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TAG_PAT }}
+          fetch-depth: 0  # need full history so `git rev-parse` can see existing tags
+
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          version=$(grep -m1 '^version' bonsai/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ -z "$version" ]; then
+            echo "::error::Could not parse version from bonsai/Cargo.toml"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $version"
+
+      - name: Check if rs-v tag already exists
+        id: check
+        run: |
+          v="${{ steps.version.outputs.version }}"
+          if git rev-parse "rs-v$v" >/dev/null 2>&1; then
+            echo "rs-v$v already exists — no-op."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rs-v$v does not exist — will tag."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Push rs-v-X.Y.Z (crates.io release)
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          v="${{ steps.version.outputs.version }}"
+          git tag "rs-v$v"
+          git push origin "rs-v$v"

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,0 +1,35 @@
+name: Rust release
+
+on:
+  push:
+    tags: ["rs-v*"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    environment:
+      name: crates-io
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Tag/version guard
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="${tag#rs-v}"
+          cargo_version=$(grep -m1 '^version' bonsai/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ "$version" != "$cargo_version" ]; then
+            echo "::error::Tag version '$version' does not match Cargo.toml version '$cargo_version'."
+            exit 1
+          fi
+
+      - name: Verify package (dry run)
+        run: cargo publish --package bonsai-bt --dry-run
+
+      - name: Publish crate
+        run: cargo publish --package bonsai-bt --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"


### PR DESCRIPTION
Addresses #67.

Mirrors the existing Python release automation (`auto-tag-py.yml` + `python-wheels.yml`) for the Rust crate `bonsai-bt`:

- `auto-tag-rust.yml`: on a push to `main` that touches `bonsai/Cargo.toml`, extract the version and push a `rs-vX.Y.Z` tag (no-op if the tag already exists). Reuses the `RELEASE_TAG_PAT` secret.
- `rust-release.yml`: on an `rs-v*` tag push, verify tag/crate version match, run `cargo publish --dry-run`, then publish to crates.io via `CARGO_REGISTRY_TOKEN` (gated behind a `crates-io` environment).

Verified locally: `cargo publish --package bonsai-bt --dry-run` packages + verifies cleanly (29 files, 218 KiB). YAML validated with `yaml.safe_load`.

Note for maintainer: the `crates-io` environment + `CARGO_REGISTRY_TOKEN` secret need to be configured in the repo settings before the publish job can run.