### PR TITLE
feat(bt): add Timeout decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ For example, if you have a state `A` and a state `B`:
 - Try `A` first and then try `B` if `A` fails: `Select([A, B])`
 - If `condition` succeedes do `A`, else do `B` : `If(condition, A, B)`
 - If `A` succeeds, return failure (and vice-versa): `Invert(A)`
+- Force a child to succeed regardless of its result: `AlwaysSucceed(A)`
+- Run a child, but fail it if it stays `Running` longer than a limit: `Timeout(seconds, A)`
 - Do `A`, `B` repeatedly while `LoopCondition` runs: `While(LoopCondition, [A, B])`. Checks condition node between nodes `A`, `B`.
 - Do `A`, `B` forever: `While(WaitForever, [A, B])`
 - Do `A`, `B` repeatedly while `LoopCondition` runs: `WhileAll(LoopCondition, [A, B])`. After *All* nodes `A`, `B` are completed successfully, check the condition node.

--- a/bonsai-py/Cargo.toml
+++ b/bonsai-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonsai-py"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.80.0"
 description = "Python bindings for the bonsai-bt behavior tree library"
@@ -28,5 +28,5 @@ path = "src/bin/stub_gen.rs"
 # list lets `cargo run --bin stub_gen` link libpython for the regular binary
 # path; maturin still activates it for the wheel build.
 pyo3 = { version = "0.28", features = ["abi3-py310"] }
-bonsai-bt = { path = "../bonsai", version = "0.13", features = ["visualize"] }
+bonsai-bt = { path = "../bonsai", version = "0.14", features = ["visualize"] }
 pyo3-stub-gen = "0.22.3"

--- a/bonsai-py/examples/README.md
+++ b/bonsai-py/examples/README.md
@@ -21,7 +21,7 @@ cd bonsai-py && maturin develop --release && cd ..
 
 After that, just `source .venv/bin/activate` + `python bonsai-py/examples/<name>.py` in any new shell.
 
-## Examples (8)
+## Examples (9)
 
 ### [simple_npc_ai.py](simple_npc_ai.py) — console NPC
 NPC runs and shoots until action points are exhausted, then rests and dies. Demonstrates `WhileAll`, blackboard mutation via `@dataclass`, structural-`match` callback.
@@ -35,6 +35,13 @@ Two short demos in one script. A memoryless `Sequence([...], memory=False)` chas
 
 ```bash
 python bonsai-py/examples/memoryless_chase.py
+```
+
+### [timeout.py](timeout.py) — `Timeout` decorator
+`Timeout(limit, child)` cuts off a still-`Running` child once the accumulated time reaches `limit` (returning `Failure`), and passes a finished child's status through unchanged.
+
+```bash
+python bonsai-py/examples/timeout.py
 ```
 
 ### [race_timeout.py](race_timeout.py) — `Race` between work and timeout

--- a/bonsai-py/examples/timeout.py
+++ b/bonsai-py/examples/timeout.py
@@ -1,0 +1,30 @@
+"""
+Demonstrates the `Timeout` decorator.
+
+`Timeout(limit, child)` runs `child`, but if `child` is still running once the
+accumulated time reaches `limit`, it is abandoned and `Failure` is returned. If
+`child` finishes (success or failure) before the limit, its status is passed
+through unchanged.
+
+Run:
+    python bonsai-py/examples/timeout.py
+"""
+from __future__ import annotations
+
+import bonsai_bt as bt
+
+
+def main() -> None:
+    # (1) A child that keeps running past the limit is cut off -> Failure.
+    tree = bt.BT(bt.Timeout(1.0, bt.Wait(5.0)), None)
+    print(f"Timeout(1.0, Wait(5.0)) @ 0.6s -> {tree.tick(0.6, None)[0]} (expect Running)")
+    print(f"Timeout(1.0, Wait(5.0)) @ 1.2s -> {tree.tick(0.6, None)[0]} (expect Failure)")
+
+    # (2) A child that finishes before the limit passes through unchanged.
+    tree2 = bt.BT(bt.Timeout(10.0, bt.Wait(0.5)), None)
+    print(f"Timeout(10.0, Wait(0.5)) @ 0.2s -> {tree2.tick(0.2, None)[0]} (expect Running)")
+    print(f"Timeout(10.0, Wait(0.5)) @ 0.6s -> {tree2.tick(0.4, None)[0]} (expect Success)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bonsai-py/python/bonsai_bt/__init__.py
+++ b/bonsai-py/python/bonsai_bt/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
     "Status", "ActionArgs", "Behavior", "BT",
     # factories (leaves, decorators, composites, control flow)
     "Action", "Wait", "WaitForever",
-    "Invert", "AlwaysSucceed",
+    "Invert", "AlwaysSucceed", "Timeout",
     "Sequence", "Select",
     "WhenAll", "WhenAny", "After", "Race",
     "If", "While", "WhileAll",

--- a/bonsai-py/python/bonsai_bt/__init__.pyi
+++ b/bonsai-py/python/bonsai_bt/__init__.pyi
@@ -17,6 +17,7 @@ __all__ = [
     "Select",
     "Sequence",
     "Status",
+    "Timeout",
     "Wait",
     "WaitForever",
     "WhenAll",
@@ -122,6 +123,8 @@ def Sequence(children: typing.Sequence[Behavior], memory: builtins.bool = True) 
     `memory=True` (default) resumes the running child across ticks.
     `memory=False` restarts from the first child every tick.
     """
+
+def Timeout(seconds: builtins.float, child: Behavior) -> Behavior: ...
 
 def Wait(seconds: builtins.float) -> Behavior: ...
 

--- a/bonsai-py/src/behavior.rs
+++ b/bonsai-py/src/behavior.rs
@@ -57,6 +57,7 @@ impl PyBehavior {
             Behavior::Action(_) => "Action(...)".to_string(),
             Behavior::Invert(_) => "Invert(...)".to_string(),
             Behavior::AlwaysSucceed(_) => "AlwaysSucceed(...)".to_string(),
+            Behavior::Timeout(t, _) => format!("Timeout({t})"),
             Behavior::Select(v) => format!("Select({})", v.len()),
             Behavior::MemorylessSelector(v) => format!("Select({}, memory=False)", v.len()),
             Behavior::If(_, _, _) => "If(...)".to_string(),
@@ -116,6 +117,19 @@ pub fn invert_fn(child: PyRef<'_, PyBehavior>) -> PyBehavior {
 #[pyo3(name = "AlwaysSucceed")]
 pub fn always_succeed_fn(child: PyRef<'_, PyBehavior>) -> PyBehavior {
     PyBehavior::wrap(Behavior::AlwaysSucceed(Box::new(child.inner.clone())))
+}
+
+#[gen_stub_pyfunction]
+#[pyfunction]
+#[pyo3(name = "Timeout")]
+pub fn timeout_fn(seconds: f64, child: PyRef<'_, PyBehavior>) -> PyResult<PyBehavior> {
+    if seconds.is_nan() {
+        return Err(PyValueError::new_err("Timeout: seconds must not be NaN"));
+    }
+    Ok(PyBehavior::wrap(Behavior::Timeout(
+        seconds as bonsai_bt::Float,
+        Box::new(child.inner.clone()),
+    )))
 }
 
 // ----- Composites (Vec<children>) -----------------------------------------

--- a/bonsai-py/src/lib.rs
+++ b/bonsai-py/src/lib.rs
@@ -8,7 +8,7 @@ mod status;
 
 use action_args::PyActionArgs;
 use behavior::{
-    action_fn, after_fn, always_succeed_fn, if_fn, invert_fn, race_fn, select_fn, sequence_fn, wait_fn,
+    action_fn, after_fn, always_succeed_fn, if_fn, invert_fn, race_fn, select_fn, sequence_fn, timeout_fn, wait_fn,
     wait_forever_fn, when_all_fn, when_any_fn, while_all_fn, while_fn, PyBehavior,
 };
 use bt::PyBT;
@@ -29,6 +29,7 @@ fn bonsai_bt(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(wait_forever_fn, m)?)?;
     m.add_function(wrap_pyfunction!(invert_fn, m)?)?;
     m.add_function(wrap_pyfunction!(always_succeed_fn, m)?)?;
+    m.add_function(wrap_pyfunction!(timeout_fn, m)?)?;
     m.add_function(wrap_pyfunction!(sequence_fn, m)?)?;
     m.add_function(wrap_pyfunction!(select_fn, m)?)?;
     m.add_function(wrap_pyfunction!(when_all_fn, m)?)?;

--- a/bonsai-py/tests/test_behavior.py
+++ b/bonsai-py/tests/test_behavior.py
@@ -9,7 +9,7 @@ import bonsai_bt as bt
 
 FACTORY_NAMES = (
     "Action", "Wait", "WaitForever",
-    "Invert", "AlwaysSucceed",
+    "Invert", "AlwaysSucceed", "Timeout",
     "Sequence", "Select",
     "WhenAll", "WhenAny", "After", "Race",
     "If", "While", "WhileAll",
@@ -19,13 +19,13 @@ FACTORY_NAMES = (
 class TestFactoriesPresent:
     @pytest.mark.parametrize("name", FACTORY_NAMES)
     def test_factory_exported(self, name: str) -> None:
-        """Each of the 16 factory names is importable and callable."""
+        """Each of the 15 factory names is importable and callable."""
         assert hasattr(bt, name), f"missing factory {name}"
         assert callable(getattr(bt, name)), f"{name} not callable"
 
     def test_factory_count(self) -> None:
-        """Exactly 14 factory names tracked — guards against silent additions."""
-        assert len(FACTORY_NAMES) == 14
+        """Exactly 15 factory names tracked — guards against silent additions."""
+        assert len(FACTORY_NAMES) == 15
 
 
 def _trivial(label: str) -> bt.Behavior:
@@ -41,6 +41,7 @@ class TestFactoryConstruction:
             (lambda: bt.WaitForever(), "WaitForever"),
             (lambda: bt.Invert(_trivial("c")), "Invert(...)"),
             (lambda: bt.AlwaysSucceed(_trivial("c")), "AlwaysSucceed(...)"),
+            (lambda: bt.Timeout(1.0, _trivial("c")), "Timeout(1)"),
             (lambda: bt.Sequence([_trivial("a"), _trivial("b")]), "Sequence(2)"),
             (lambda: bt.Select([_trivial("a")]), "Select(1)"),
             (lambda: bt.Sequence([_trivial("a"), _trivial("b")], memory=False), "Sequence(2, memory=False)"),
@@ -166,6 +167,7 @@ class TestIdentityEquality:
             lambda: bt.WaitForever(),
             lambda: bt.Invert(bt.Action("x")),
             lambda: bt.AlwaysSucceed(bt.Action("x")),
+            lambda: bt.Timeout(1.0, bt.Action("x")),
             lambda: bt.Sequence([bt.Action("x")]),
             lambda: bt.Select([bt.Action("x")]),
             lambda: bt.WhenAll([bt.Action("x")]),
@@ -332,6 +334,20 @@ class TestBehaviorRustParity:
         r = b.tick(0.0, yields_failure)
         assert r is not None
         assert r[0] == bt.Status.Success
+
+    def test_timeout_halts_running_child(self) -> None:
+        """Timeout cuts off a still-Running child once the limit is exceeded."""
+        b = bt.BT(bt.Timeout(1.0, bt.Wait(5.0)), None)
+        assert b.tick(0.5, None)[0] == bt.Status.Running
+        assert b.tick(0.4, None)[0] == bt.Status.Running
+        # 0.5 + 0.4 + 0.2 = 1.1 >= 1.0 -> Failure.
+        assert b.tick(0.2, None)[0] == bt.Status.Failure
+
+    def test_timeout_passes_through_completed_child(self) -> None:
+        """Child finishes (Success) before the limit, so Timeout passes it through."""
+        b = bt.BT(bt.Timeout(10.0, bt.Wait(0.5)), None)
+        assert b.tick(0.2, None)[0] == bt.Status.Running
+        assert b.tick(0.4, None)[0] == bt.Status.Success
 
     def test_when_all_waits_for_all(self) -> None:
         """WhenAll blocks the parent Sequence until both parallel children finish."""

--- a/bonsai-py/tests/test_module.py
+++ b/bonsai-py/tests/test_module.py
@@ -5,8 +5,8 @@ import bonsai_bt as bt
 
 
 def test_version_present() -> None:
-    """bt.__version__ pins the wheel version (0.13.0); bump per release."""
-    assert bt.__version__ == "0.13.0"
+    """bt.__version__ pins the wheel version (0.14.0); bump per release."""
+    assert bt.__version__ == "0.14.0"
 
 
 def test_docstring_present() -> None:
@@ -16,11 +16,11 @@ def test_docstring_present() -> None:
 
 
 def test_all_contents() -> None:
-    """__all__ contains exactly the 4 types + 14 factories + RUNNING = 19 names."""
+    """__all__ contains exactly the 4 types + 15 factories + RUNNING = 20 names."""
     expected = {
         "Status", "ActionArgs", "Behavior", "BT",
         "Action", "Wait", "WaitForever",
-        "Invert", "AlwaysSucceed",
+        "Invert", "AlwaysSucceed", "Timeout",
         "Sequence", "Select",
         "WhenAll", "WhenAny", "After", "Race",
         "If", "While", "WhileAll",

--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -12,7 +12,7 @@ name = "bonsai-bt"
 readme = "../README.md"
 repository = "https://github.com/sollimann/bonsai.git"
 rust-version = "1.80.0"
-version = "0.13.1"
+version = "0.14.0"
 
 [lib]
 name = "bonsai_bt"

--- a/bonsai/src/behavior.rs
+++ b/bonsai/src/behavior.rs
@@ -30,6 +30,14 @@ pub enum Behavior<A> {
     Invert(Box<Behavior<A>>),
     /// Ignores failures and returns `Success`.
     AlwaysSucceed(Box<Behavior<A>>),
+    /// Halts the child and returns `Failure` if it stays `Running` longer
+    /// than the given time limit.
+    ///
+    /// Accumulates the elapsed time across ticks while the child is
+    /// `Running`. Once the accumulated time reaches the limit, the child is
+    /// abandoned and `Failure` is returned. If the child finishes (succeeds
+    /// or fails) before the limit, its status is returned unchanged.
+    Timeout(Float, Box<Behavior<A>>),
     /// Runs behaviors one by one until one succeeds.
     ///
     /// Tries the next behavior if one fails. Fails if the last fails.

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -120,8 +120,8 @@
 //! ```
 
 pub use behavior::Behavior::{
-    self, Action, After, AlwaysSucceed, If, Invert, Race, Select, Sequence, Wait, WaitForever, WhenAll, WhenAny, While,
-    WhileAll,
+    self, Action, After, AlwaysSucceed, If, Invert, Race, Select, Sequence, Timeout, Wait, WaitForever, WhenAll,
+    WhenAny, While, WhileAll,
 };
 
 pub use bt::BT;

--- a/bonsai/src/state.rs
+++ b/bonsai/src/state.rs
@@ -36,6 +36,13 @@ pub(crate) enum State<A> {
     Invert(Box<State<A>>),
     /// Ignores failures and always return `Success`.
     AlwaysSucceed(Box<State<A>>),
+    /// Keeps track of a `Timeout` decorator: the child plus the accumulated
+    /// running time.
+    Timeout {
+        time_limit: Float,
+        elapsed_time: Float,
+        child: Box<State<A>>,
+    },
     /// Keeps track of waiting for a period of time before continuing.
     Wait { time_to_wait: Float, elapsed_time: Float },
     /// Waits forever.
@@ -144,6 +151,11 @@ impl<A: Clone> State<A> {
             Behavior::Action(action) => State::Action(action),
             Behavior::Invert(ev) => State::Invert(Box::new(State::new(*ev))),
             Behavior::AlwaysSucceed(ev) => State::AlwaysSucceed(Box::new(State::new(*ev))),
+            Behavior::Timeout(time_limit, ev) => State::Timeout {
+                time_limit,
+                elapsed_time: 0.0,
+                child: Box::new(State::new(*ev)),
+            },
             Behavior::Wait(dt) => State::Wait {
                 time_to_wait: dt,
                 elapsed_time: 0.0,
@@ -277,6 +289,32 @@ impl<A: Clone> State<A> {
                 };
                 tracer.record(self_id, result.0);
                 result
+            }
+            (
+                _,
+                &mut Timeout {
+                    time_limit,
+                    ref mut elapsed_time,
+                    ref mut child,
+                },
+            ) => {
+                let child_id = first_child_id::<T>(self_id);
+                match child.tick(child_id, metas, e, blackboard, f, tracer) {
+                    (Running, _) => {
+                        *elapsed_time += upd.unwrap_or(0.0);
+                        let result = if *elapsed_time >= time_limit {
+                            (Failure, 0.0)
+                        } else {
+                            RUNNING
+                        };
+                        tracer.record(self_id, result.0);
+                        result
+                    }
+                    (status, dt) => {
+                        tracer.record(self_id, status);
+                        (status, dt)
+                    }
+                }
             }
             (
                 Some(dt),

--- a/bonsai/src/telemetry.rs
+++ b/bonsai/src/telemetry.rs
@@ -81,7 +81,7 @@ pub(crate) fn children_of<A>(b: &Behavior<A>) -> Vec<&Behavior<A>> {
     use Behavior::*;
     match b {
         Action(_) | Wait(_) | WaitForever => vec![],
-        Invert(c) | AlwaysSucceed(c) => vec![c.as_ref()],
+        Invert(c) | AlwaysSucceed(c) | Timeout(_, c) => vec![c.as_ref()],
         // [condition, on_success, on_failure] — must match skip_subtree logic.
         If(cond, ok, ko) => vec![cond.as_ref(), ok.as_ref(), ko.as_ref()],
         While(cond, body) | WhileAll(cond, body) => {
@@ -112,6 +112,7 @@ fn classify<A: std::fmt::Debug>(b: &Behavior<A>) -> (&'static str, Option<String
         WaitForever => ("WaitForever", None),
         Invert(_) => ("Inverter", None),
         AlwaysSucceed(_) => ("AlwaysSucceed", None),
+        Timeout(t, _) => ("Timeout", Some(format!("Timeout({t:.2}s)"))),
         Select(_) => ("Selector", None),
         MemorylessSelector(_) => ("MemorylessSelector", None),
         Sequence(_) => ("Sequence", None),

--- a/bonsai/src/visualizer.rs
+++ b/bonsai/src/visualizer.rs
@@ -11,6 +11,7 @@ pub(crate) enum NodeType<A> {
     Action(A),
     Invert,
     AlwaysSucceed,
+    Timeout(Float),
     Select,
     If,
     Sequence,
@@ -42,6 +43,11 @@ impl<A: Clone + Debug, K: Debug> BT<A, K> {
             }
             Behavior::AlwaysSucceed(ev) => {
                 let node_id = graph.add_node(NodeType::AlwaysSucceed);
+                graph.add_edge(parent_node, node_id, 1);
+                Self::dfs_recursive(graph, *ev, node_id)
+            }
+            Behavior::Timeout(seconds, ev) => {
+                let node_id = graph.add_node(NodeType::Timeout(seconds));
                 graph.add_edge(parent_node, node_id, 1);
                 Self::dfs_recursive(graph, *ev, node_id)
             }

--- a/bonsai/tests/behavior_tests.rs
+++ b/bonsai/tests/behavior_tests.rs
@@ -1,7 +1,7 @@
 use crate::behavior_tests::TestActions::{Dec, Inc, LessThan, LessThanRunningSuccess};
 use bonsai_bt::{
     Action, ActionArgs, After, AlwaysSucceed, Event, Failure, Float, If, Invert, Race, Select, Sequence,
-    Status::Running, Success, UpdateArgs, Wait, WaitForever, WhenAll, WhenAny, While, WhileAll, BT,
+    Status::Running, Success, Timeout, UpdateArgs, Wait, WaitForever, WhenAll, WhenAny, While, WhileAll, BT,
 };
 
 /// Some test actions.
@@ -375,6 +375,35 @@ fn test_always_succeed() {
     let (a, s, _) = tick(a, 0.1, &mut state);
     assert_eq!(a, 3);
     assert_eq!(s, Running);
+}
+
+#[test]
+fn test_timeout_halts_running_child() {
+    // A child that keeps Running until it succeeds; the Timeout should cut it
+    // off and return Failure once the limit is exceeded.
+    let behavior = Timeout(1.0, Box::new(Wait(5.0)));
+    let mut state = BT::new(behavior, ());
+
+    let (_, s, _) = tick(0, 0.5, &mut state);
+    assert_eq!(s, Running);
+    let (_, s, _) = tick(0, 0.4, &mut state);
+    assert_eq!(s, Running);
+    // 0.5 + 0.4 = 0.9 < 1.0, still running.
+    let (_, s, _) = tick(0, 0.2, &mut state);
+    // 0.9 + 0.2 = 1.1 >= 1.0 -> Failure.
+    assert_eq!(s, Failure);
+}
+
+#[test]
+fn test_timeout_passes_through_completed_child() {
+    // Child finishes (Success) before the limit, so Timeout returns Success.
+    let behavior = Timeout(10.0, Box::new(Wait(0.5)));
+    let mut state = BT::new(behavior, ());
+
+    let (_, s, _) = tick(0, 0.2, &mut state);
+    assert_eq!(s, Running);
+    let (_, s, _) = tick(0, 0.4, &mut state);
+    assert_eq!(s, Success);
 }
 
 #[test]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -33,6 +33,10 @@ name = "async_drone"
 path = "src/async_drone/main.rs"
 
 [[bin]]
+name = "timeout"
+path = "src/timeout/main.rs"
+
+[[bin]]
 name = "3d"
 path = "src/3d/main.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -91,6 +91,12 @@ This simple example shows an example of using the Race behavior to time out a lo
   <img src="https://github.com/Sollimann/bonsai/blob/main/docs/resources/images/race_timeout.png" width="700">
 </p>
 
+## Timeout decorator
+
+Demonstrates the `Timeout(limit, child)` decorator: if `child` stays `Running` past the accumulated time limit, it is abandoned and `Failure` is returned; if `child` finishes first, its status passes through unchanged.
+
+`cargo run --bin timeout`
+
 ## WebSocket visualizer (live tree inspector)
 
 A live web-based visualizer for a running behavior tree. The example builds a 30-node tree (one memoryless `Sequence` and one memoryless `Select` included — `memory = false`, both drawn with a dashed circle), enables the visualizer via a single API call `BT::with_telemetry(8910)`, and re-ticks every ~400 ms so leaf statuses (green / yellow / red) and the running-path highlight animate continuously.

--- a/examples/src/timeout/main.rs
+++ b/examples/src/timeout/main.rs
@@ -1,0 +1,39 @@
+//! Demonstrates the `Timeout` decorator.
+//!
+//! `Timeout(limit, child)` runs `child`, but if `child` is still `Running`
+//! once the accumulated time reaches `limit`, it is abandoned and `Failure`
+//! is returned. If `child` finishes (success or failure) before the limit,
+//! its status is passed through unchanged.
+use bonsai_bt::Behavior::{Timeout, Wait};
+use bonsai_bt::{Event, Float, Status, UpdateArgs, BT};
+
+/// Advance the tree by `dt` seconds and return the resulting `(Status, Float)`.
+fn tick(bt: &mut BT<(), ()>, dt: Float) -> Option<(Status, Float)> {
+    let e: Event = UpdateArgs { dt }.into();
+    // No `Action` nodes in these trees, so the callback is never invoked.
+    bt.tick(&e, &mut |_, _| (Status::Running, 0.0))
+}
+
+fn main() {
+    // (1) A child that keeps Running past the limit is cut off -> Failure.
+    let mut bt = BT::new(Timeout(1.0, Box::new(Wait(5.0))), ());
+    println!(
+        "Timeout(1.0, Wait(5.0)) @ 0.6s -> {:?} (expect Running)",
+        tick(&mut bt, 0.6)
+    );
+    println!(
+        "Timeout(1.0, Wait(5.0)) @ 1.2s -> {:?} (expect Failure)",
+        tick(&mut bt, 0.6)
+    );
+
+    // (2) A child that finishes before the limit passes through unchanged.
+    let mut bt2 = BT::new(Timeout(10.0, Box::new(Wait(0.5))), ());
+    println!(
+        "Timeout(10.0, Wait(0.5)) @ 0.2s -> {:?} (expect Running)",
+        tick(&mut bt2, 0.2)
+    );
+    println!(
+        "Timeout(10.0, Wait(0.5)) @ 0.6s -> {:?} (expect Success)",
+        tick(&mut bt2, 0.4)
+    );
+}


### PR DESCRIPTION
Part of #78 (one decorator per PR, per maintainer request).

Adds `Behavior::Timeout(Float, Box<Behavior<A>>)` that halts its child and returns `Failure` if the child stays `Running` longer than the given time limit.

- Elapsed time accumulates across ticks while the child is `Running`; once it reaches the limit the child is abandoned and `Failure` is returned.
- A child that completes (`Success`/`Failure`) before the limit passes through unchanged.
- Wired through `State::new`/`State::tick`, telemetry node metadata, the visualizer graph, and the Python bindings (`Timeout` factory + `__repr__`).
- Tests: `test_timeout_halts_running_child`, `test_timeout_passes_through_completed_child`.

`cargo test -p bonsai-bt` — 53 passed; `cargo build -p bonsai-bt --all-features` — ok; `cargo fmt --check` — clean.