### PR TITLE
feat(bt): add AlwaysFail (ForceFailure) decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ For example, if you have a state `A` and a state `B`:
 - Try `A` first and then try `B` if `A` fails: `Select([A, B])`
 - If `condition` succeedes do `A`, else do `B` : `If(condition, A, B)`
 - If `A` succeeds, return failure (and vice-versa): `Invert(A)`
+- Force a child to succeed regardless of its result: `AlwaysSucceed(A)`
+- Force a child to fail regardless of its result: `AlwaysFail(A)`
 - Do `A`, `B` repeatedly while `LoopCondition` runs: `While(LoopCondition, [A, B])`. Checks condition node between nodes `A`, `B`.
 - Do `A`, `B` forever: `While(WaitForever, [A, B])`
 - Do `A`, `B` repeatedly while `LoopCondition` runs: `WhileAll(LoopCondition, [A, B])`. After *All* nodes `A`, `B` are completed successfully, check the condition node.

--- a/bonsai-py/Cargo.toml
+++ b/bonsai-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonsai-py"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.80.0"
 description = "Python bindings for the bonsai-bt behavior tree library"
@@ -28,5 +28,5 @@ path = "src/bin/stub_gen.rs"
 # list lets `cargo run --bin stub_gen` link libpython for the regular binary
 # path; maturin still activates it for the wheel build.
 pyo3 = { version = "0.28", features = ["abi3-py310"] }
-bonsai-bt = { path = "../bonsai", version = "0.13", features = ["visualize"] }
+bonsai-bt = { path = "../bonsai", version = "0.14", features = ["visualize"] }
 pyo3-stub-gen = "0.22.3"

--- a/bonsai-py/examples/force_result.py
+++ b/bonsai-py/examples/force_result.py
@@ -1,0 +1,47 @@
+"""
+Demonstrates the `AlwaysSucceed` and `AlwaysFail` decorators.
+
+`AlwaysSucceed(A)` coerces a child's Failure into Success — useful for
+best-effort nodes (telemetry, logging) that must not abort a Sequence.
+
+`AlwaysFail(A)` coerces a child's Success into Failure — useful for
+probes/guards that should always route the tree down a fallback branch.
+
+Run:
+    python bonsai-py/examples/force_result.py
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import bonsai_bt as bt
+
+
+def flaky_telemetry(_args: Any, _bb: Any) -> tuple[bt.Status, float]:
+    """A best-effort node that reports Failure (e.g. telemetry send failed)."""
+    return (bt.Status.Failure, 0.0)
+
+
+def probe(_args: Any, _bb: Any) -> tuple[bt.Status, float]:
+    """A probe that reports Success (e.g. the resource was found)."""
+    return (bt.Status.Success, 0.0)
+
+
+def main() -> None:
+    # (1) AlwaysSucceed — the flaky telemetry node fails, but the decorator
+    #     coerces it to Success so it doesn't abort its parent Sequence.
+    telemetry = bt.AlwaysSucceed(bt.Action("flaky-telemetry"))
+    tree = bt.BT(telemetry, None)
+    result = tree.tick(0.0, flaky_telemetry)
+    print(f"AlwaysSucceed(flaky telemetry) -> {result[0]} (expect Success)")
+
+    # (2) AlwaysFail — the probe succeeds, but the decorator coerces it to
+    #     Failure so control flow is forced down a fallback branch.
+    probe_tree = bt.AlwaysFail(bt.Action("probe"))
+    tree2 = bt.BT(probe_tree, None)
+    result2 = tree2.tick(0.0, probe)
+    print(f"AlwaysFail(probe) -> {result2[0]} (expect Failure)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bonsai-py/python/bonsai_bt/__init__.py
+++ b/bonsai-py/python/bonsai_bt/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
     "Status", "ActionArgs", "Behavior", "BT",
     # factories (leaves, decorators, composites, control flow)
     "Action", "Wait", "WaitForever",
-    "Invert", "AlwaysSucceed",
+    "Invert", "AlwaysSucceed", "AlwaysFail",
     "Sequence", "Select",
     "WhenAll", "WhenAny", "After", "Race",
     "If", "While", "WhileAll",

--- a/bonsai-py/python/bonsai_bt/__init__.pyi
+++ b/bonsai-py/python/bonsai_bt/__init__.pyi
@@ -8,6 +8,7 @@ __all__ = [
     "Action",
     "ActionArgs",
     "After",
+    "AlwaysFail",
     "AlwaysSucceed",
     "BT",
     "Behavior",
@@ -98,6 +99,8 @@ class Status(enum.Enum):
 def Action(action: typing.Any) -> Behavior: ...
 
 def After(children: typing.Sequence[Behavior]) -> Behavior: ...
+
+def AlwaysFail(child: Behavior) -> Behavior: ...
 
 def AlwaysSucceed(child: Behavior) -> Behavior: ...
 

--- a/bonsai-py/src/behavior.rs
+++ b/bonsai-py/src/behavior.rs
@@ -57,6 +57,7 @@ impl PyBehavior {
             Behavior::Action(_) => "Action(...)".to_string(),
             Behavior::Invert(_) => "Invert(...)".to_string(),
             Behavior::AlwaysSucceed(_) => "AlwaysSucceed(...)".to_string(),
+            Behavior::AlwaysFail(_) => "AlwaysFail(...)".to_string(),
             Behavior::Select(v) => format!("Select({})", v.len()),
             Behavior::MemorylessSelector(v) => format!("Select({}, memory=False)", v.len()),
             Behavior::If(_, _, _) => "If(...)".to_string(),
@@ -116,6 +117,13 @@ pub fn invert_fn(child: PyRef<'_, PyBehavior>) -> PyBehavior {
 #[pyo3(name = "AlwaysSucceed")]
 pub fn always_succeed_fn(child: PyRef<'_, PyBehavior>) -> PyBehavior {
     PyBehavior::wrap(Behavior::AlwaysSucceed(Box::new(child.inner.clone())))
+}
+
+#[gen_stub_pyfunction]
+#[pyfunction]
+#[pyo3(name = "AlwaysFail")]
+pub fn always_fail_fn(child: PyRef<'_, PyBehavior>) -> PyBehavior {
+    PyBehavior::wrap(Behavior::AlwaysFail(Box::new(child.inner.clone())))
 }
 
 // ----- Composites (Vec<children>) -----------------------------------------

--- a/bonsai-py/src/lib.rs
+++ b/bonsai-py/src/lib.rs
@@ -8,7 +8,7 @@ mod status;
 
 use action_args::PyActionArgs;
 use behavior::{
-    action_fn, after_fn, always_succeed_fn, if_fn, invert_fn, race_fn, select_fn, sequence_fn, wait_fn,
+    action_fn, after_fn, always_fail_fn, always_succeed_fn, if_fn, invert_fn, race_fn, select_fn, sequence_fn, wait_fn,
     wait_forever_fn, when_all_fn, when_any_fn, while_all_fn, while_fn, PyBehavior,
 };
 use bt::PyBT;
@@ -29,6 +29,7 @@ fn bonsai_bt(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(wait_forever_fn, m)?)?;
     m.add_function(wrap_pyfunction!(invert_fn, m)?)?;
     m.add_function(wrap_pyfunction!(always_succeed_fn, m)?)?;
+    m.add_function(wrap_pyfunction!(always_fail_fn, m)?)?;
     m.add_function(wrap_pyfunction!(sequence_fn, m)?)?;
     m.add_function(wrap_pyfunction!(select_fn, m)?)?;
     m.add_function(wrap_pyfunction!(when_all_fn, m)?)?;

--- a/bonsai-py/tests/test_behavior.py
+++ b/bonsai-py/tests/test_behavior.py
@@ -1,4 +1,4 @@
-"""Behavior class + 14 factory functions + ports of Rust behavior_tests."""
+"""Behavior class + 15 factory functions + ports of Rust behavior_tests."""
 from __future__ import annotations
 
 from typing import Any, Callable
@@ -9,7 +9,7 @@ import bonsai_bt as bt
 
 FACTORY_NAMES = (
     "Action", "Wait", "WaitForever",
-    "Invert", "AlwaysSucceed",
+    "Invert", "AlwaysSucceed", "AlwaysFail",
     "Sequence", "Select",
     "WhenAll", "WhenAny", "After", "Race",
     "If", "While", "WhileAll",
@@ -19,13 +19,13 @@ FACTORY_NAMES = (
 class TestFactoriesPresent:
     @pytest.mark.parametrize("name", FACTORY_NAMES)
     def test_factory_exported(self, name: str) -> None:
-        """Each of the 16 factory names is importable and callable."""
+        """Each of the 15 factory names is importable and callable."""
         assert hasattr(bt, name), f"missing factory {name}"
         assert callable(getattr(bt, name)), f"{name} not callable"
 
     def test_factory_count(self) -> None:
-        """Exactly 14 factory names tracked — guards against silent additions."""
-        assert len(FACTORY_NAMES) == 14
+        """Exactly 15 factory names tracked — guards against silent additions."""
+        assert len(FACTORY_NAMES) == 15
 
 
 def _trivial(label: str) -> bt.Behavior:
@@ -41,6 +41,7 @@ class TestFactoryConstruction:
             (lambda: bt.WaitForever(), "WaitForever"),
             (lambda: bt.Invert(_trivial("c")), "Invert(...)"),
             (lambda: bt.AlwaysSucceed(_trivial("c")), "AlwaysSucceed(...)"),
+            (lambda: bt.AlwaysFail(_trivial("c")), "AlwaysFail(...)"),
             (lambda: bt.Sequence([_trivial("a"), _trivial("b")]), "Sequence(2)"),
             (lambda: bt.Select([_trivial("a")]), "Select(1)"),
             (lambda: bt.Sequence([_trivial("a"), _trivial("b")], memory=False), "Sequence(2, memory=False)"),
@@ -332,6 +333,26 @@ class TestBehaviorRustParity:
         r = b.tick(0.0, yields_failure)
         assert r is not None
         assert r[0] == bt.Status.Success
+
+    def test_always_fail_coerces_success(self) -> None:
+        """AlwaysFail coerces a child's Success into Failure."""
+        def yields_success(_a: Any, _b: Any) -> tuple[bt.Status, float]:
+            return (bt.Status.Success, 0.0)
+
+        b = bt.BT(bt.AlwaysFail(bt.Action("x")), None)
+        r = b.tick(0.0, yields_success)
+        assert r is not None
+        assert r[0] == bt.Status.Failure
+
+    def test_always_fail_passes_through_running(self) -> None:
+        """AlwaysFail lets a Running child keep Running (it doesn't force Failure early)."""
+        def yields_running(_a: Any, _b: Any) -> tuple[bt.Status, float]:
+            return (bt.Status.Running, 0.0)
+
+        b = bt.BT(bt.AlwaysFail(bt.Action("x")), None)
+        r = b.tick(0.0, yields_running)
+        assert r is not None
+        assert r[0] == bt.Status.Running
 
     def test_when_all_waits_for_all(self) -> None:
         """WhenAll blocks the parent Sequence until both parallel children finish."""

--- a/bonsai-py/tests/test_module.py
+++ b/bonsai-py/tests/test_module.py
@@ -5,8 +5,8 @@ import bonsai_bt as bt
 
 
 def test_version_present() -> None:
-    """bt.__version__ pins the wheel version (0.13.0); bump per release."""
-    assert bt.__version__ == "0.13.0"
+    """bt.__version__ pins the wheel version (0.14.0); bump per release."""
+    assert bt.__version__ == "0.14.0"
 
 
 def test_docstring_present() -> None:

--- a/bonsai-py/tests/test_module.py
+++ b/bonsai-py/tests/test_module.py
@@ -16,11 +16,11 @@ def test_docstring_present() -> None:
 
 
 def test_all_contents() -> None:
-    """__all__ contains exactly the 4 types + 14 factories + RUNNING = 19 names."""
+    """__all__ contains exactly the 4 types + 15 factories + RUNNING = 20 names."""
     expected = {
         "Status", "ActionArgs", "Behavior", "BT",
         "Action", "Wait", "WaitForever",
-        "Invert", "AlwaysSucceed",
+        "Invert", "AlwaysSucceed", "AlwaysFail",
         "Sequence", "Select",
         "WhenAll", "WhenAny", "After", "Race",
         "If", "While", "WhileAll",

--- a/bonsai/Cargo.toml
+++ b/bonsai/Cargo.toml
@@ -12,7 +12,7 @@ name = "bonsai-bt"
 readme = "../README.md"
 repository = "https://github.com/sollimann/bonsai.git"
 rust-version = "1.80.0"
-version = "0.13.1"
+version = "0.14.0"
 
 [lib]
 name = "bonsai_bt"

--- a/bonsai/src/behavior.rs
+++ b/bonsai/src/behavior.rs
@@ -30,6 +30,11 @@ pub enum Behavior<A> {
     Invert(Box<Behavior<A>>),
     /// Ignores failures and returns `Success`.
     AlwaysSucceed(Box<Behavior<A>>),
+    /// Ignores the child's outcome and returns `Failure` once it completes.
+    ///
+    /// Passes through `Running` so the child is allowed to finish. The mirror
+    /// of [`AlwaysSucceed`](Behavior::AlwaysSucceed).
+    AlwaysFail(Box<Behavior<A>>),
     /// Runs behaviors one by one until one succeeds.
     ///
     /// Tries the next behavior if one fails. Fails if the last fails.

--- a/bonsai/src/lib.rs
+++ b/bonsai/src/lib.rs
@@ -120,8 +120,8 @@
 //! ```
 
 pub use behavior::Behavior::{
-    self, Action, After, AlwaysSucceed, If, Invert, Race, Select, Sequence, Wait, WaitForever, WhenAll, WhenAny, While,
-    WhileAll,
+    self, Action, After, AlwaysFail, AlwaysSucceed, If, Invert, Race, Select, Sequence, Wait, WaitForever, WhenAll,
+    WhenAny, While, WhileAll,
 };
 
 pub use bt::BT;

--- a/bonsai/src/state.rs
+++ b/bonsai/src/state.rs
@@ -36,6 +36,8 @@ pub(crate) enum State<A> {
     Invert(Box<State<A>>),
     /// Ignores failures and always return `Success`.
     AlwaysSucceed(Box<State<A>>),
+    /// Ignores the child's outcome and always return `Failure`.
+    AlwaysFail(Box<State<A>>),
     /// Keeps track of waiting for a period of time before continuing.
     Wait { time_to_wait: Float, elapsed_time: Float },
     /// Waits forever.
@@ -144,6 +146,7 @@ impl<A: Clone> State<A> {
             Behavior::Action(action) => State::Action(action),
             Behavior::Invert(ev) => State::Invert(Box::new(State::new(*ev))),
             Behavior::AlwaysSucceed(ev) => State::AlwaysSucceed(Box::new(State::new(*ev))),
+            Behavior::AlwaysFail(ev) => State::AlwaysFail(Box::new(State::new(*ev))),
             Behavior::Wait(dt) => State::Wait {
                 time_to_wait: dt,
                 elapsed_time: 0.0,
@@ -274,6 +277,15 @@ impl<A: Clone> State<A> {
                 let result = match cur.tick(child_id, metas, e, blackboard, f, tracer) {
                     (Running, dt) => (Running, dt),
                     (_, dt) => (Success, dt),
+                };
+                tracer.record(self_id, result.0);
+                result
+            }
+            (_, &mut AlwaysFail(ref mut cur)) => {
+                let child_id = first_child_id::<T>(self_id);
+                let result = match cur.tick(child_id, metas, e, blackboard, f, tracer) {
+                    (Running, dt) => (Running, dt),
+                    (_, dt) => (Failure, dt),
                 };
                 tracer.record(self_id, result.0);
                 result

--- a/bonsai/src/telemetry.rs
+++ b/bonsai/src/telemetry.rs
@@ -81,7 +81,7 @@ pub(crate) fn children_of<A>(b: &Behavior<A>) -> Vec<&Behavior<A>> {
     use Behavior::*;
     match b {
         Action(_) | Wait(_) | WaitForever => vec![],
-        Invert(c) | AlwaysSucceed(c) => vec![c.as_ref()],
+        Invert(c) | AlwaysSucceed(c) | AlwaysFail(c) => vec![c.as_ref()],
         // [condition, on_success, on_failure] — must match skip_subtree logic.
         If(cond, ok, ko) => vec![cond.as_ref(), ok.as_ref(), ko.as_ref()],
         While(cond, body) | WhileAll(cond, body) => {
@@ -112,6 +112,7 @@ fn classify<A: std::fmt::Debug>(b: &Behavior<A>) -> (&'static str, Option<String
         WaitForever => ("WaitForever", None),
         Invert(_) => ("Inverter", None),
         AlwaysSucceed(_) => ("AlwaysSucceed", None),
+        AlwaysFail(_) => ("AlwaysFail", None),
         Select(_) => ("Selector", None),
         MemorylessSelector(_) => ("MemorylessSelector", None),
         Sequence(_) => ("Sequence", None),

--- a/bonsai/src/visualizer.rs
+++ b/bonsai/src/visualizer.rs
@@ -11,6 +11,7 @@ pub(crate) enum NodeType<A> {
     Action(A),
     Invert,
     AlwaysSucceed,
+    AlwaysFail,
     Select,
     If,
     Sequence,
@@ -42,6 +43,11 @@ impl<A: Clone + Debug, K: Debug> BT<A, K> {
             }
             Behavior::AlwaysSucceed(ev) => {
                 let node_id = graph.add_node(NodeType::AlwaysSucceed);
+                graph.add_edge(parent_node, node_id, 1);
+                Self::dfs_recursive(graph, *ev, node_id)
+            }
+            Behavior::AlwaysFail(ev) => {
+                let node_id = graph.add_node(NodeType::AlwaysFail);
                 graph.add_edge(parent_node, node_id, 1);
                 Self::dfs_recursive(graph, *ev, node_id)
             }

--- a/bonsai/tests/behavior_tests.rs
+++ b/bonsai/tests/behavior_tests.rs
@@ -1,6 +1,6 @@
 use crate::behavior_tests::TestActions::{Dec, Inc, LessThan, LessThanRunningSuccess};
 use bonsai_bt::{
-    Action, ActionArgs, After, AlwaysSucceed, Event, Failure, Float, If, Invert, Race, Select, Sequence,
+    Action, ActionArgs, After, AlwaysFail, AlwaysSucceed, Event, Failure, Float, If, Invert, Race, Select, Sequence,
     Status::Running, Success, UpdateArgs, Wait, WaitForever, WhenAll, WhenAny, While, WhileAll, BT,
 };
 
@@ -345,6 +345,29 @@ fn test_select_and_invert() {
     state.reset_bt();
     let (a, s, _) = tick(a, 0.1, &mut state);
     assert_eq!(a, 0);
+    assert_eq!(s, Failure);
+}
+
+#[test]
+fn test_always_fail() {
+    // Child succeeds; AlwaysFail must still report Failure once it completes.
+    let behavior = AlwaysFail(Box::new(Action(Inc)));
+    let mut state = BT::new(behavior, ());
+
+    let (a, s, _) = tick(0, 0.1, &mut state);
+    assert_eq!(a, 1);
+    assert_eq!(s, Failure);
+}
+
+#[test]
+fn test_always_fail_passes_through_running() {
+    // A Running child (Wait) must be reported as Running, not Failure.
+    let behavior = AlwaysFail(Box::new(Wait(0.5)));
+    let mut state = BT::new(behavior, ());
+
+    let (_, s, _) = tick(0, 0.1, &mut state);
+    assert_eq!(s, Running);
+    let (_, s, _) = tick(0, 0.5, &mut state);
     assert_eq!(s, Failure);
 }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -59,3 +59,7 @@ path = "src/visualizer_smoke/main.rs"
 [[bin]]
 name = "memoryless_chase"
 path = "src/memoryless_chase/main.rs"
+
+[[bin]]
+name = "force_result"
+path = "src/force_result/main.rs"

--- a/examples/src/force_result/main.rs
+++ b/examples/src/force_result/main.rs
@@ -1,0 +1,53 @@
+//! Demonstrates the `AlwaysSucceed` and `AlwaysFail` decorators.
+//!
+//! `AlwaysSucceed(A)` coerces a child's result to `Success` even when the child
+//! reports `Failure` — useful for best-effort nodes (telemetry, logging) that
+//! must not abort the surrounding `Sequence`.
+//!
+//! `AlwaysFail(A)` coerces a child's result to `Failure` even when the child
+//! reports `Success` — useful for probes/guards that should always route the
+//! tree down a fallback branch.
+use bonsai_bt::Behavior::{Action, AlwaysFail, AlwaysSucceed};
+use bonsai_bt::{Event, Status, UpdateArgs, BT};
+
+#[derive(Clone, Debug)]
+enum Op {
+    /// Reports `Failure` (e.g. a telemetry send that failed).
+    FlakyTelemetry,
+    /// Reports `Success` (e.g. a probe that found the resource).
+    Probe,
+}
+
+fn main() {
+    let e: Event = UpdateArgs { dt: 0.0 }.into();
+
+    // (1) AlwaysSucceed — the flaky telemetry node fails, but the decorator
+    //     coerces it to Success so it doesn't abort its parent Sequence.
+    let telemetry = AlwaysSucceed(Box::new(Action(Op::FlakyTelemetry)));
+    let mut bt = BT::new(telemetry, ());
+    let (status, _) = bt
+        .tick(
+            &e,
+            &mut |args: bonsai_bt::ActionArgs<Event, Op>, _| match *args.action {
+                Op::FlakyTelemetry => (Status::Failure, 0.0),
+                Op::Probe => (Status::Success, 0.0),
+            },
+        )
+        .expect("tree should yield a result");
+    println!("AlwaysSucceed(flaky telemetry) -> {status:?} (expect Success)");
+
+    // (2) AlwaysFail — the probe succeeds, but the decorator coerces it to
+    //     Failure so control flow is forced down a fallback branch.
+    let probe = AlwaysFail(Box::new(Action(Op::Probe)));
+    let mut bt2 = BT::new(probe, ());
+    let (status2, _) = bt2
+        .tick(
+            &e,
+            &mut |args: bonsai_bt::ActionArgs<Event, Op>, _| match *args.action {
+                Op::FlakyTelemetry => (Status::Failure, 0.0),
+                Op::Probe => (Status::Success, 0.0),
+            },
+        )
+        .expect("tree should yield a result");
+    println!("AlwaysFail(probe) -> {status2:?} (expect Failure)");
+}


### PR DESCRIPTION
## Summary

Adds an `AlwaysFail` decorator — the mirror of the existing `AlwaysSucceed` — completing the "Force Result" half of #78.

`AlwaysFail(child)` runs the child to completion but reports `Failure` regardless of its final outcome, passing `Running` through so the child is allowed to finish. (`ForceSuccess` is already covered by the existing `AlwaysSucceed` decorator.)

## Changes

- `Behavior::AlwaysFail` / `State::AlwaysFail` variant + tick logic (mirrors `AlwaysSucceed`)
- telemetry `children_of` / `classify` + visualizer `NodeType` entry
- Python bindings: `AlwaysFail` factory + `__repr__`
- Tests:
  - `test_always_fail` — a succeeding child is forced to `Failure`
  - `test_always_fail_passes_through_running` — a `Running` child is reported as `Running`, not `Failure`

## Verification

- `cargo test -p bonsai-bt --all-features` → 78 passed, 1 ignored
- `cargo clippy -p bonsai-bt --all-features` → clean
- `cargo check -p bonsai-py` → ok
- `cargo fmt --all` → clean

Closes part of #78 (Force Result). One decorator per PR, per your request.